### PR TITLE
Old FireMmrService Performance Fix & Continuation implemented

### DIFF
--- a/src/pax.dsstats.dbng/Replay.cs
+++ b/src/pax.dsstats.dbng/Replay.cs
@@ -174,7 +174,7 @@ public class ReplayPlayer
     public int GamePos { get; set; }
     public int Team { get; set; }
     public PlayerResult PlayerResult { get; set; }
-    public float MmrChange { get; set; }
+    public float? MmrChange { get; set; } = null;
     public int Duration { get; set; }
     public Commander Race { get; set; }
     public Commander OppRace { get; set; }

--- a/src/pax.dsstats.shared/ReplayDsRDto.cs
+++ b/src/pax.dsstats.shared/ReplayDsRDto.cs
@@ -21,7 +21,7 @@ public record ReplayPlayerDsRDto
     public Commander OppRace { get; init; }
     public int Duration { get; init; }
     public bool IsUploader { get; init; }
-    public float MmrChange { get; set; }
+    public float? MmrChange { get; set; } = null;
 }
 
 public record PlayerDsRDto

--- a/src/pax.dsstats.shared/ReplayDto.cs
+++ b/src/pax.dsstats.shared/ReplayDto.cs
@@ -48,7 +48,7 @@ public record ReplayPlayerDto
     public int GamePos { get; init; }
     public int Team { get; init; }
     public PlayerResult PlayerResult { get; init; }
-    public float MmrChange { get; set; }
+    public float? MmrChange { get; set; } = null;
     public int Duration { get; init; }
     public Commander Race { get; init; }
     public Commander OppRace { get; init; }

--- a/src/sc2dsstats.razorlib/Replay/ReplayComponent.razor
+++ b/src/sc2dsstats.razorlib/Replay/ReplayComponent.razor
@@ -35,7 +35,7 @@
                     {
                         var players = replayDto.ReplayPlayers.Where(x => x.Team == i).OrderBy(o => o.GamePos).ToList();
                         bool isWinner = replayDto.WinnerTeam == i;
-                        var hasMmrChanges = replayDto.ReplayPlayers.Any(f => f.MmrChange != 0);
+                        var hasMmrChanges = replayDto.ReplayPlayers.Any(f => f.MmrChange.GetValueOrDefault(0) != 0);
 
                         <div class="col-auto">
                             <div class="d-flex">
@@ -76,7 +76,7 @@
                                                 @if (hasMmrChanges)
                                                 {
                                                     <td class="table-dark">
-                                                        <span class="oi @(player.MmrChange < 0 ? "oi-arrow-bottom text-danger" : "oi-arrow-top text-success")">@player.MmrChange.ToString("N1", CultureInfo.InvariantCulture)</span>
+                                                        <span class="oi @(player.MmrChange.GetValueOrDefault(0) < 0 ? "oi-arrow-bottom text-danger" : "oi-arrow-top text-success")">@player.MmrChange.GetValueOrDefault(0).ToString("N1", CultureInfo.InvariantCulture)</span>
                                                     </td>
                                                 }
                                                 <td>


### PR DESCRIPTION
- Peformance fix in SetRatings durch bessere Db-Kommunikation
- MmrChange nullable mit funktionierender möglichkeit zu calculation-continuation

- Wichtig!!! Brauche Migration-edit für ‘MmrChange’ in ‘ReplayPlayers’.
(MmrChange Nullable & MmrChange default NULL)