### PR TITLE
Small hot fix

### DIFF
--- a/src/dsstats.maui.tests/MmrCalculationTests.cs
+++ b/src/dsstats.maui.tests/MmrCalculationTests.cs
@@ -371,15 +371,11 @@ public class MmrCalculationTests : TestWithSqlite
             var entBefore = dataAfterContinue.ElementAt(i);
             Assert.True(mmrService.ToonIdRatings.ContainsKey(entBefore.Key));
             var entAfter = dataAfterReRecalculate[entBefore.Key];
-            
-            if (entBefore.Value.Mmr != entAfter.Mmr) {
-            }
-            if (entBefore.Value.Consistency != entAfter.Consistency) {
-            }
-            if (entBefore.Value.Uncertainty != entAfter.Uncertainty) {
-            }
 
             Assert.Equal(entBefore.Value.Mmr, entAfter.Mmr);
+            Assert.Equal(entBefore.Value.ConsistencyUp, entAfter.ConsistencyUp);
+            Assert.Equal(entBefore.Value.ConsistencyDown, entAfter.ConsistencyDown);
+            Assert.Equal(entBefore.Value.Uncertainty, entAfter.Uncertainty);
         }
     }
 

--- a/src/dsstats.maui.tests/MmrCalculationTests.cs
+++ b/src/dsstats.maui.tests/MmrCalculationTests.cs
@@ -373,8 +373,7 @@ public class MmrCalculationTests : TestWithSqlite
             var entAfter = dataAfterReRecalculate[entBefore.Key];
 
             Assert.Equal(entBefore.Value.Mmr, entAfter.Mmr);
-            Assert.Equal(entBefore.Value.ConsistencyUp, entAfter.ConsistencyUp);
-            Assert.Equal(entBefore.Value.ConsistencyDown, entAfter.ConsistencyDown);
+            Assert.Equal(entBefore.Value.Consistency, entAfter.Consistency);
             Assert.Equal(entBefore.Value.Uncertainty, entAfter.Uncertainty);
         }
     }

--- a/src/pax.dsstats.dbng/Services/MmrService/MmrService.Cmdr.cs
+++ b/src/pax.dsstats.dbng/Services/MmrService/MmrService.Cmdr.cs
@@ -119,7 +119,9 @@ public partial class MmrService
 
     private void SetCmdrMmrs(Dictionary<int, List<DsRCheckpoint>> playerRatingsCmdr, TeamData teamData)
     {
-        teamData.CmdrComboMmr = GetCommandersComboMmr(teamData.Players);
+        if (useCommanderMmr) {
+            teamData.CmdrComboMmr = GetCommandersComboMmr(teamData.Players);
+        }
         teamData.PlayersMeanMmr = GetPlayersComboMmr(playerRatingsCmdr, teamData.Players);
     }
 
@@ -204,9 +206,14 @@ public partial class MmrService
     {
         double commandersComboMMRSum = 0;
 
-        for (int playerIndex = 0; playerIndex < teamPlayers.Length; playerIndex++)
-        {
+        for (int playerIndex = 0; playerIndex < teamPlayers.Length; playerIndex++) {
             var playerCmdr = teamPlayers[playerIndex].ReplayPlayer.Race;
+
+            if ((int)playerCmdr <= 3) {
+                commandersComboMMRSum += startMmr;
+                continue;
+            }
+
 
             double synergySum = 0;
             double antiSynergySum = 0;

--- a/src/pax.dsstats.dbng/Services/MmrService/MmrService.Cmdr.cs
+++ b/src/pax.dsstats.dbng/Services/MmrService/MmrService.Cmdr.cs
@@ -30,6 +30,7 @@ public partial class MmrService
 
         var weightedSum = playerRatingsCmdr.Sum(x => ((x.Value.Count - 1) * x.Value.Last().Uncertainty));
         var weightedUncertanity = weightedSum / playerRatingsCmdr.Sum(x => (x.Value.Count - 1));
+        var accuracy = 1 - weightedUncertanity;
 
         return playerRatingsCmdr;
     }
@@ -137,7 +138,7 @@ public partial class MmrService
             }
 
             double factor_playerToTeamMates = PlayerToTeamMates(teamData.PlayersMeanMmr, playerMmr, teamData.Players.Length);
-            double factor_consistency = GetCorrectedRevConsistency(1 - playerConsistency);
+            double factor_consistency = /*consistencyImpact * replayProcessData.Uncertainty; //*/GetCorrectedRevConsistency(1 - playerConsistency);
             double factor_uncertainty = (1 - replayProcessData.Uncertainty);
 
             double playerImpact = 1

--- a/src/pax.dsstats.dbng/Services/MmrService/MmrService.Cmdr.cs
+++ b/src/pax.dsstats.dbng/Services/MmrService/MmrService.Cmdr.cs
@@ -57,9 +57,9 @@ public partial class MmrService
             return;
         }
 
-        if (replay.ReplayPlayers.Any(a => (int)a.Race <= 3))
+        if (replay.ReplayPlayers.Any(a => (int)a.Race <= 3) && replay.ReplayPlayers.Min(x => x.Duration > 0))
         {
-            logger.LogDebug($"skipping wrong cmdr commanders");
+            logger.LogDebug($"skipping invalid commanders");
             return;
         }
 

--- a/src/pax.dsstats.dbng/Services/MmrService/ReplayProcessData.cs
+++ b/src/pax.dsstats.dbng/Services/MmrService/ReplayProcessData.cs
@@ -9,8 +9,8 @@ internal record ReplayProcessData
         ReplayGameTime = replay.GameTime;
         Duration = replay.Duration;
 
-        WinnerTeamData = new(replay, replay.ReplayPlayers.Where(x => x.Team == replay.WinnerTeam));
-        LoserTeamData = new(replay, replay.ReplayPlayers.Where(x => x.Team != replay.WinnerTeam));
+        WinnerTeamData = new(replay, replay.ReplayPlayers.Where(x => x.Team == replay.WinnerTeam), true);
+        LoserTeamData = new(replay, replay.ReplayPlayers.Where(x => x.Team != replay.WinnerTeam), false);
     }
 
     public TeamData WinnerTeamData { get; init; }
@@ -27,9 +27,10 @@ internal record ReplayProcessData
 
 internal record TeamData
 {
-    public TeamData(ReplayDsRDto replay, IEnumerable<ReplayPlayerDsRDto> replayPlayers)
+    public TeamData(ReplayDsRDto replay, IEnumerable<ReplayPlayerDsRDto> replayPlayers, bool isWinner)
     {
         Players = replayPlayers.Select(x => new PlayerData(replay, x)).ToArray();
+        this.IsWinner = isWinner;
     }
 
     public PlayerData[] Players { get; init; }
@@ -38,6 +39,8 @@ internal record TeamData
     public double CmdrComboMmr { get; set; }
 
     public double UncertaintyDelta { get; set; }
+
+    public bool IsWinner { get; init; }
 }
 
 internal record PlayerData


### PR DESCRIPTION
- When a player leaves in a commander game without pre selecting the replays still counts and handle's him as leaver now. (Important for Web version)
- Added IsWinner Info to ReplayProccesData bzw TeamData