### PR TITLE
Leaver handling

### DIFF
--- a/src/dsstats.mmr/MmrService.Calc.cs
+++ b/src/dsstats.mmr/MmrService.Calc.cs
@@ -38,7 +38,7 @@ public static partial class MmrService
             }
             else
             {
-                SetLeaverPlayerDeltas(playerData, replayData, playerImpact, mmrOptions);
+                SetLeaverPlayerDeltas(playerData, teamData, replayData, playerImpact, mmrOptions);
             }
 
             //if (Math.Abs(playerData.Deltas.Mmr) > mmrOptions.EloK * teamData.Players.Length)
@@ -56,9 +56,17 @@ public static partial class MmrService
         playerData.Deltas.Confidence = 1 - Math.Abs(teamData.ExpectedResult - teamData.ActualResult);
     }
 
-    private static void SetLeaverPlayerDeltas(PlayerData playerData, ReplayData replayData, double playerImpact, MmrOptions mmrOptions)
+    private static void SetLeaverPlayerDeltas(PlayerData playerData, TeamData teamData, ReplayData replayData, double playerImpact, MmrOptions mmrOptions)
     {
-        playerData.Deltas.Mmr = -1 * CalculateMmrDelta(replayData.LoserTeamData.ExpectedResult, playerImpact, mmrOptions.EloK); //ToDo
+        if (teamData.ActualResult == replayData.WinnerTeamData.ActualResult)
+        {
+            playerData.Deltas.Mmr = -1 * CalculateMmrDelta(replayData.LoserTeamData.ExpectedResult, playerImpact, mmrOptions.EloK); //ToDo
+        }
+        else
+        {
+            playerData.Deltas.Mmr = -1 * CalculateMmrDelta(replayData.WinnerTeamData.ExpectedResult, playerImpact, mmrOptions.EloK); //ToDo
+        }
+
         playerData.Deltas.Consistency = 0;
         playerData.Deltas.Confidence = 0;
     }

--- a/src/dsstats.mmr/MmrService.ProcessData.cs
+++ b/src/dsstats.mmr/MmrService.ProcessData.cs
@@ -7,7 +7,7 @@ namespace dsstats.mmr;
 
 public partial class MmrService
 {
-    private static void SetReplayData(Dictionary<int, CalcRating> mmrIdRatings,
+    public static void SetReplayData(Dictionary<int, CalcRating> mmrIdRatings,
                                       ReplayData replayData,
                                       Dictionary<CmdrMmmrKey, CmdrMmmrValue> cmdrDic,
                                       MmrOptions mmrOptions)


### PR DESCRIPTION
comment from discord:
"es ist gefixed. aber das senario wenn leaver im winnerteam sind ist viel schwerer um die werte zu bekommen die er eigentlich braucht. im debuggen sind die werte aber korrekt, nur der abgleich ist schwierig. ich lass jetzt kurz meine db laufen und such die scenarien jeweils und mache dann den PR."