### PR TITLE
Add builds gas and upgrade timing modals

### DIFF
--- a/src/common/dsstats.shared/BuildsRequest.cs
+++ b/src/common/dsstats.shared/BuildsRequest.cs
@@ -43,6 +43,22 @@ public class BuildUnit
     public double Life { get; set; }
 }
 
+public class BuildUpgradeTimingDto
+{
+    public string Upgrade { get; set; } = string.Empty;
+    public double AverageTimeSeconds { get; set; }
+    public int Count { get; set; }
+    public double UsagePercent { get; set; }
+}
+
+public class BuildGasTimingDto
+{
+    public int Gas { get; set; }
+    public double AverageTimeSeconds { get; set; }
+    public int Count { get; set; }
+    public double UsagePercent { get; set; }
+}
+
 public static class BuildRequestExtensions
 {
     public static string GetMemKey(this BuildsRequest request)

--- a/src/common/dsstats.shared/Interfaces/IBuildsService.cs
+++ b/src/common/dsstats.shared/Interfaces/IBuildsService.cs
@@ -5,6 +5,8 @@ namespace dsstats.shared.Interfaces;
 public interface IBuildsService
 {
     Task<BuildsResponse> GetBuildResponse(BuildsRequest request, CancellationToken token = default);
+    Task<List<BuildUpgradeTimingDto>> GetUpgradeTimings(BuildsRequest request, CancellationToken token = default);
+    Task<List<BuildGasTimingDto>> GetGasTimings(BuildsRequest request, CancellationToken token = default);
     Task<List<DsUnitListDto>> GetUnits(DsUnitsRequest request);
     Task<DsUnitDto> GetUnit(int dsUnitId);
 }

--- a/src/common/dsstats.weblib/Builds/BuildsComponent.razor
+++ b/src/common/dsstats.weblib/Builds/BuildsComponent.razor
@@ -58,7 +58,7 @@
 					<div class="card h-100 border-0 shadow-sm">
 						<div class="card-body bgchart2 text-center">
 							<div class="text-muted small mb-1">Avg Gain</div>
-							<h3 class="mb-0 text-nowrap text-success">@response.Stats.AvgGain.ToString("F2")</h3>
+							<h3 class="mb-0 text-nowrap @GetAvgGainClass(response.Stats.AvgGain)">@response.Stats.AvgGain.ToString("F2")</h3>
 						</div>
 					</div>
 				</div>
@@ -72,10 +72,26 @@
 				</div>
 				<div class="col-sm-4 col-md-3 col-lg-2">
 					<div class="card h-100 border-0 shadow-sm">
-						<div class="card-body bgchart2 text-center">
+						<button class="card-body bgchart2 text-center border-0 w-100 h-100 pointer position-relative"
+								type="button"
+								title="Show average gas timing"
+								@onclick="ShowGasTimings">
+							<i class="bi bi-fuel-pump position-absolute top-0 end-0 mt-1 me-2 text-warning small" aria-hidden="true"></i>
 							<div class="text-muted small mb-1">Gas</div>
 							<h3 class="mb-0 text-nowrap text-warning">@response.Stats.Gas.ToString("F2")</h3>
-						</div>
+						</button>
+					</div>
+				</div>
+				<div class="col-sm-4 col-md-3 col-lg-2">
+					<div class="card h-100 border-0 shadow-sm">
+						<button class="card-body bgchart2 text-center border-0 w-100 h-100 pointer position-relative"
+								type="button"
+								title="Show average upgrade timing"
+								@onclick="ShowUpgradeTimings">
+							<i class="bi bi-clock-history position-absolute top-0 end-0 mt-1 me-2 text-info small" aria-hidden="true"></i>
+							<div class="text-muted small mb-1">Upgrades</div>
+							<h3 class="mb-0 text-nowrap text-info">@response.Stats.Upgrades.ToString("N0")</h3>
+						</button>
 					</div>
 				</div>
 			</div>
@@ -273,6 +289,23 @@
 	</div>
 </div>
 
+<TimingModal @ref="gasTimingModal"
+			 ModalId="@gasTimingModalId"
+			 Title="@($"Average Gas Timing for {Request.Interest}")"
+			 NameColumn="Gas"
+			 LoadingText="Loading gas timings..."
+			 EmptyText="No gas timing data available for the selected criteria."
+			 BadgeTitle="Only gas timings with count greater than 9 are shown" />
+
+<TimingModal @ref="upgradeTimingModal"
+			 ModalId="@upgradeTimingModalId"
+			 Title="@($"Average Upgrade Timing for {Request.Interest}")"
+			 NameColumn="Upgrade"
+			 LoadingText="Loading upgrade timings..."
+			 EmptyText="No upgrade timing data available for the selected criteria."
+			 BadgeTitle="Only upgrades with count greater than 9 are shown"
+			 HighlightTopUsageRows="true" />
+
 <ReplayModal @ref="replayModal" IsCloseable="true" IsScrollable="true" OnPlayerRequest="e => playerModal?.Show(e)" OnClose="CloseReplay" />
 <PlayerModal @ref="playerModal" OnClose="e => replayModal?.Show(ReplayDetails!)" />
 
@@ -290,6 +323,10 @@
 	BuildSpawnComponent? buildSpawnComponent;
 	bool showSpawns;
 	string replayHash = string.Empty;
+	string upgradeTimingModalId = "buildUpgradeTimingModal";
+	string gasTimingModalId = "buildGasTimingModal";
+	TimingModal? upgradeTimingModal;
+	TimingModal? gasTimingModal;
 	ReplayModal? replayModal;
 	PlayerModal? playerModal;
 	ReplayDetails? ReplayDetails = null;
@@ -311,6 +348,8 @@
 	private async Task LoadData(bool dry = false)
 	{
 		isLoading = true;
+		upgradeTimingModal?.Clear();
+		gasTimingModal?.Clear();
 		await InvokeAsync(StateHasChanged);
 		response = await BuildsService.GetBuildResponse(Request, cts.Token);
 		isLoading = false;
@@ -329,6 +368,11 @@
 		if (winrate >= 50) return "#0d6efd"; // primary blue
 		if (winrate >= 40) return "#fd7e14"; // warning orange
 		return "#dc3545"; // danger red
+	}
+
+	private string GetAvgGainClass(double avgGain)
+	{
+		return avgGain < 0 ? "text-danger" : "text-success";
 	}
 
 	private string FormatDuration(double seconds)
@@ -371,6 +415,38 @@
 		{
 			buildSpawnComponent?.Update(replayHash, Request);
 		}
+	}
+
+	private async Task ShowUpgradeTimings()
+	{
+		if (upgradeTimingModal is null)
+		{
+			return;
+		}
+
+		await upgradeTimingModal.Show(async token =>
+		{
+			var timings = await BuildsService.GetUpgradeTimings(Request, token);
+			return timings
+				.Select(timing => new TimingModalRow(timing.Upgrade, timing.AverageTimeSeconds, timing.Count, timing.UsagePercent))
+				.ToList();
+		}, cts.Token);
+	}
+
+	private async Task ShowGasTimings()
+	{
+		if (gasTimingModal is null)
+		{
+			return;
+		}
+
+		await gasTimingModal.Show(async token =>
+		{
+			var timings = await BuildsService.GetGasTimings(Request, token);
+			return timings
+				.Select(timing => new TimingModalRow($"Gas {timing.Gas}", timing.AverageTimeSeconds, timing.Count, timing.UsagePercent))
+				.ToList();
+		}, cts.Token);
 	}
 
 	public void Dispose()

--- a/src/common/dsstats.weblib/Builds/TimingModal.razor
+++ b/src/common/dsstats.weblib/Builds/TimingModal.razor
@@ -1,0 +1,263 @@
+@using System.Globalization
+@using Microsoft.JSInterop
+@inject IJSRuntime JSRuntime
+
+<div class="modal" id="@ModalId" aria-hidden="true" aria-labelledby="@ModalId" tabindex="-1">
+	<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
+		<div class="modal-content">
+			<div class="modal-header bgchart2">
+				<h5 class="modal-title">
+					@Title
+					<span class="badge text-bg-secondary ms-2" title="@BadgeTitle">&sum; &gt; 9</span>
+				</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div class="modal-body bgchart">
+				@if (isLoading)
+				{
+					<div class="d-flex align-items-center gap-2">
+						<div class="spinner-border" role="status">
+							<span class="visually-hidden">Loading...</span>
+						</div>
+						<span>@LoadingText</span>
+					</div>
+				}
+				else if (timings.Count == 0)
+				{
+					<div class="alert alert-info mb-0" role="alert">
+						<i class="bi bi-info-circle me-2"></i>
+						@EmptyText
+					</div>
+				}
+				else
+				{
+					<div class="table-responsive">
+						<table class="@GetTableClass()">
+							<thead>
+								<tr>
+									<th>
+										<button class="btn btn-link p-0 text-decoration-none text-reset" type="button" @onclick='() => SortTimings(nameof(TimingModalRow.Name))'>
+											@NameColumn
+											<span class="bi @GetSortIcon(nameof(TimingModalRow.Name)) ms-1" aria-hidden="true"></span>
+										</button>
+									</th>
+									<th class="text-end">
+										<button class="btn btn-link p-0 text-decoration-none text-reset" type="button" @onclick='() => SortTimings(nameof(TimingModalRow.AverageTimeSeconds))'>
+											Avg Time
+											<span class="bi @GetSortIcon(nameof(TimingModalRow.AverageTimeSeconds)) ms-1" aria-hidden="true"></span>
+										</button>
+									</th>
+									<th class="text-end">
+										<button class="btn btn-link p-0 text-decoration-none text-reset" type="button" @onclick='() => SortTimings(nameof(TimingModalRow.Count))'>
+											Count
+											<span class="bi @GetSortIcon(nameof(TimingModalRow.Count)) ms-1" aria-hidden="true"></span>
+										</button>
+									</th>
+									<th class="text-end">
+										<button class="btn btn-link p-0 text-decoration-none text-reset" type="button" @onclick='() => SortTimings(nameof(TimingModalRow.UsagePercent))'>
+											%
+											<span class="bi @GetSortIcon(nameof(TimingModalRow.UsagePercent)) ms-1" aria-hidden="true"></span>
+										</button>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								@foreach (var timing in GetSortedTimings())
+								{
+									<tr class="@GetTimingRowClass(timing)">
+										<td>@timing.Name</td>
+										<td class="text-end">@FormatTiming(timing.AverageTimeSeconds)</td>
+										<td class="text-end">@timing.Count.ToString("N0", CultureInfo.CurrentCulture)</td>
+										<td class="text-end">@timing.UsagePercent.ToString("F1", CultureInfo.CurrentCulture)%</td>
+									</tr>
+								}
+							</tbody>
+						</table>
+					</div>
+				}
+			</div>
+		</div>
+	</div>
+</div>
+
+@code {
+	[Parameter, EditorRequired]
+	public string ModalId { get; set; } = default!;
+
+	[Parameter, EditorRequired]
+	public string Title { get; set; } = default!;
+
+	[Parameter, EditorRequired]
+	public string NameColumn { get; set; } = default!;
+
+	[Parameter, EditorRequired]
+	public string LoadingText { get; set; } = default!;
+
+	[Parameter, EditorRequired]
+	public string EmptyText { get; set; } = default!;
+
+	[Parameter, EditorRequired]
+	public string BadgeTitle { get; set; } = default!;
+
+	[Parameter]
+	public bool HighlightTopUsageRows { get; set; }
+
+	List<TimingModalRow> timings = [];
+	HashSet<string> highlightedTimings = new(StringComparer.OrdinalIgnoreCase);
+	bool isLoading;
+	string sortColumn = nameof(TimingModalRow.AverageTimeSeconds);
+	bool sortAscending = true;
+
+	public async Task Show(Func<CancellationToken, Task<List<TimingModalRow>>> loadTimings, CancellationToken token = default)
+	{
+		timings = [];
+		highlightedTimings.Clear();
+		isLoading = true;
+		await InvokeAsync(StateHasChanged);
+		await JSRuntime.InvokeVoidAsync("openModalById", ModalId);
+		try
+		{
+			SetTimings(await loadTimings(token));
+		}
+		catch (OperationCanceledException)
+		{
+			timings = [];
+			highlightedTimings.Clear();
+		}
+		finally
+		{
+			isLoading = false;
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	public void Clear()
+	{
+		timings = [];
+		highlightedTimings.Clear();
+		isLoading = false;
+	}
+
+	private string GetTableClass()
+	{
+		return HighlightTopUsageRows ? "tptable timing-modal-highlight-table" : "tptable";
+	}
+
+	private string GetTimingRowClass(TimingModalRow timing)
+	{
+		return highlightedTimings.Contains(timing.Name) ? "timing-modal-highlight" : string.Empty;
+	}
+
+	private void SetTimings(List<TimingModalRow> newTimings)
+	{
+		timings = newTimings;
+		highlightedTimings = HighlightTopUsageRows
+			? GetHighlightedTimings(timings)
+			: [];
+	}
+
+	private IEnumerable<TimingModalRow> GetSortedTimings()
+	{
+		return sortColumn switch
+		{
+			nameof(TimingModalRow.Name) => sortAscending
+				? timings.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+				: timings.OrderByDescending(x => x.Name, StringComparer.OrdinalIgnoreCase),
+			nameof(TimingModalRow.Count) => sortAscending
+				? timings.OrderBy(x => x.Count)
+				: timings.OrderByDescending(x => x.Count),
+			nameof(TimingModalRow.UsagePercent) => sortAscending
+				? timings.OrderBy(x => x.UsagePercent)
+				: timings.OrderByDescending(x => x.UsagePercent),
+			_ => sortAscending
+				? timings.OrderBy(x => x.AverageTimeSeconds)
+				: timings.OrderByDescending(x => x.AverageTimeSeconds)
+		};
+	}
+
+	private void SortTimings(string column)
+	{
+		if (sortColumn == column)
+		{
+			sortAscending = !sortAscending;
+			return;
+		}
+
+		sortColumn = column;
+		sortAscending = true;
+	}
+
+	private string GetSortIcon(string column)
+	{
+		return sortColumn == column
+			? (sortAscending ? "bi-caret-up-fill" : "bi-caret-down-fill")
+			: string.Empty;
+	}
+
+	private static string FormatTiming(double seconds)
+	{
+		return TimeSpan.FromSeconds(seconds).ToString(@"hh\:mm\:ss", CultureInfo.InvariantCulture);
+	}
+
+	private static HashSet<string> GetHighlightedTimings(List<TimingModalRow> sourceTimings)
+	{
+		var topTimings = new List<TimingModalRow>(Math.Min(5, sourceTimings.Count));
+		foreach (var timing in sourceTimings)
+		{
+			var insertIndex = -1;
+			for (var i = 0; i < topTimings.Count; i++)
+			{
+				if (CompareTimingHighlight(timing, topTimings[i]) < 0)
+				{
+					insertIndex = i;
+					break;
+				}
+			}
+
+			if (insertIndex < 0)
+			{
+				if (topTimings.Count < 5)
+				{
+					topTimings.Add(timing);
+				}
+				continue;
+			}
+
+			topTimings.Insert(insertIndex, timing);
+			if (topTimings.Count > 5)
+			{
+				topTimings.RemoveAt(5);
+			}
+		}
+
+		var highlights = new HashSet<string>(topTimings.Count, StringComparer.OrdinalIgnoreCase);
+		foreach (var timing in topTimings)
+		{
+			highlights.Add(timing.Name);
+		}
+		return highlights;
+	}
+
+	private static int CompareTimingHighlight(TimingModalRow left, TimingModalRow right)
+	{
+		var usageCompare = right.UsagePercent.CompareTo(left.UsagePercent);
+		if (usageCompare != 0)
+		{
+			return usageCompare;
+		}
+
+		var countCompare = right.Count.CompareTo(left.Count);
+		if (countCompare != 0)
+		{
+			return countCompare;
+		}
+
+		var timeCompare = left.AverageTimeSeconds.CompareTo(right.AverageTimeSeconds);
+		if (timeCompare != 0)
+		{
+			return timeCompare;
+		}
+
+		return StringComparer.OrdinalIgnoreCase.Compare(left.Name, right.Name);
+	}
+}

--- a/src/common/dsstats.weblib/Builds/TimingModalRow.cs
+++ b/src/common/dsstats.weblib/Builds/TimingModalRow.cs
@@ -1,0 +1,3 @@
+namespace dsstats.weblib.Builds;
+
+public sealed record TimingModalRow(string Name, double AverageTimeSeconds, int Count, double UsagePercent);

--- a/src/common/dsstats.weblib/wwwroot/css/dsstats.css
+++ b/src/common/dsstats.weblib/wwwroot/css/dsstats.css
@@ -51,6 +51,10 @@
         background-color: #12243aE6;
     }
 
+    .tptable.timing-modal-highlight-table tbody tr.timing-modal-highlight > td:first-child {
+        box-shadow: inset 3px 0 0 rgba(13, 202, 240, 0.7);
+    }
+
 .preload-terran {
     background-image: url("/_content/dsstats.weblib/images/terran-min.png");
     background-repeat: no-repeat;

--- a/src/server/dsstats.api/Controllers/BuildsController.cs
+++ b/src/server/dsstats.api/Controllers/BuildsController.cs
@@ -17,6 +17,20 @@ public class BuildsController(IBuildsService buildsService) : Controller
         return Ok(response);
     }
 
+    [HttpPost("upgrades/timing")]
+    public async Task<ActionResult<List<BuildUpgradeTimingDto>>> GetUpgradeTimings([FromBody] BuildsRequest request, CancellationToken token = default)
+    {
+        var timings = await buildsService.GetUpgradeTimings(request, token);
+        return Ok(timings);
+    }
+
+    [HttpPost("gas/timing")]
+    public async Task<ActionResult<List<BuildGasTimingDto>>> GetGasTimings([FromBody] BuildsRequest request, CancellationToken token = default)
+    {
+        var timings = await buildsService.GetGasTimings(request, token);
+        return Ok(timings);
+    }
+
     [HttpPost("units")]
     public async Task<ActionResult<List<DsUnitListDto>>> GetUnits(DsUnitsRequest request)
     {

--- a/src/server/dsstats.apiServices/BuildsService.cs
+++ b/src/server/dsstats.apiServices/BuildsService.cs
@@ -23,6 +23,34 @@ public class BuildsService(IHttpClientFactory httpClientFactory) : IBuildsServic
         }
     }
 
+    public async Task<List<BuildUpgradeTimingDto>> GetUpgradeTimings(BuildsRequest request, CancellationToken token = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync("api10/Builds/upgrades/timing", request, token);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<List<BuildUpgradeTimingDto>>(cancellationToken: token) ?? [];
+        }
+        catch (Exception)
+        {
+            return [];
+        }
+    }
+
+    public async Task<List<BuildGasTimingDto>> GetGasTimings(BuildsRequest request, CancellationToken token = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync("api10/Builds/gas/timing", request, token);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<List<BuildGasTimingDto>>(cancellationToken: token) ?? [];
+        }
+        catch (Exception)
+        {
+            return [];
+        }
+    }
+
     public async Task<List<DsUnitListDto>> GetUnits(DsUnitsRequest request)
     {
         try

--- a/src/server/dsstats.dbServices/Builds/BuildsService.cs
+++ b/src/server/dsstats.dbServices/Builds/BuildsService.cs
@@ -3,6 +3,7 @@ using dsstats.shared;
 using dsstats.shared.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using System.Runtime.InteropServices;
 
 namespace dsstats.dbServices.Builds;
 
@@ -29,6 +30,54 @@ public partial class BuildsService(IDbContextFactory<DsstatsContext> contextFact
         catch (OperationCanceledException)
         {
             return new BuildsResponse();
+        }
+    }
+
+    public async Task<List<BuildUpgradeTimingDto>> GetUpgradeTimings(BuildsRequest request, CancellationToken token = default)
+    {
+        var memKey = $"{request.GetMemKey()}_upgrade_timing";
+        try
+        {
+            return await memoryCache.GetOrCreateAsync(memKey, async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(24);
+                await using var context = await contextFactory.CreateDbContextAsync(token);
+                var timeInfo = Data.GetTimePeriodInfo(request.TimePeriod);
+                if (timeInfo is null)
+                {
+                    return [];
+                }
+
+                return await CreateUpgradeTimings(request, timeInfo, context, token);
+            }) ?? [];
+        }
+        catch (OperationCanceledException)
+        {
+            return [];
+        }
+    }
+
+    public async Task<List<BuildGasTimingDto>> GetGasTimings(BuildsRequest request, CancellationToken token = default)
+    {
+        var memKey = $"{request.GetMemKey()}_gas_timing";
+        try
+        {
+            return await memoryCache.GetOrCreateAsync(memKey, async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(24);
+                await using var context = await contextFactory.CreateDbContextAsync(token);
+                var timeInfo = Data.GetTimePeriodInfo(request.TimePeriod);
+                if (timeInfo is null)
+                {
+                    return [];
+                }
+
+                return await CreateGasTimings(request, timeInfo, context, token);
+            }) ?? [];
+        }
+        catch (OperationCanceledException)
+        {
+            return [];
         }
     }
 
@@ -119,5 +168,130 @@ public partial class BuildsService(IDbContextFactory<DsstatsContext> contextFact
 
         var buildCounts = await query.FirstOrDefaultAsync(token);
         return buildCounts ?? new();
+    }
+
+    private static async Task<List<BuildUpgradeTimingDto>> CreateUpgradeTimings(
+        BuildsRequest request,
+        TimePeriodInfo timeInfo,
+        DsstatsContext context,
+        CancellationToken token)
+    {
+        var matchingReplayPlayers = GetMatchingBuildReplayPlayers(request, timeInfo, context);
+        var cmdrCount = await matchingReplayPlayers.CountAsync(token);
+        if (cmdrCount == 0)
+        {
+            return [];
+        }
+
+        var maxUpgradeSecond = GetBreakpointSeconds(request.Breakpoint);
+        var query = from rp in matchingReplayPlayers
+                    from upgrade in rp.Upgrades
+                    where upgrade.Gameloop <= maxUpgradeSecond
+                    && !upgrade.Upgrade!.Name.StartsWith("PlayerState")
+                    group upgrade by upgrade.Upgrade!.Name into g
+                    where g.Count() >= 10
+                    orderby g.Average(x => x.Gameloop), g.Count() descending
+                    select new BuildUpgradeTimingDto()
+                    {
+                        Upgrade = g.Key,
+                        AverageTimeSeconds = Math.Round(g.Average(x => x.Gameloop), 2),
+                        Count = g.Count(),
+                        UsagePercent = Math.Round(100.0 * g.Count() / cmdrCount, 2)
+                    };
+
+        return await query.ToListAsync(token);
+    }
+
+    private static async Task<List<BuildGasTimingDto>> CreateGasTimings(
+        BuildsRequest request,
+        TimePeriodInfo timeInfo,
+        DsstatsContext context,
+        CancellationToken token)
+    {
+        var matchingReplayPlayers = GetMatchingBuildReplayPlayers(request, timeInfo, context);
+        var cmdrCount = await matchingReplayPlayers.CountAsync(token);
+        if (cmdrCount == 0)
+        {
+            return [];
+        }
+
+        var maxGasSecond = GetBreakpointSeconds(request.Breakpoint);
+        var refineryTimings = await matchingReplayPlayers
+            .Select(x => x.Refineries)
+            .ToListAsync(token);
+
+        Dictionary<int, GasTimingAccumulator> timings = [];
+        foreach (var refineries in refineryTimings)
+        {
+            var gas = 0;
+            foreach (var refinerySecond in refineries.Order())
+            {
+                if (refinerySecond > maxGasSecond)
+                {
+                    break;
+                }
+
+                gas++;
+                ref var timing = ref CollectionsMarshal.GetValueRefOrAddDefault(timings, gas, out _);
+                timing.Count++;
+                timing.TotalSeconds += refinerySecond;
+            }
+        }
+
+        return timings
+            .Where(x => x.Value.Count >= 10)
+            .OrderBy(x => x.Key)
+            .Select(x => new BuildGasTimingDto()
+            {
+                Gas = x.Key,
+                AverageTimeSeconds = Math.Round(x.Value.TotalSeconds / (double)x.Value.Count, 2),
+                Count = x.Value.Count,
+                UsagePercent = Math.Round(100.0 * x.Value.Count / cmdrCount, 2)
+            })
+            .ToList();
+    }
+
+    private static IQueryable<ReplayPlayer> GetMatchingBuildReplayPlayers(
+        BuildsRequest request,
+        TimePeriodInfo timeInfo,
+        DsstatsContext context)
+    {
+        var playerIds = request.Players.Select(s => s.PlayerId).ToHashSet();
+        var noPlayers = playerIds.Count == 0;
+
+        return from rp in context.ReplayPlayers.AsNoTracking()
+               join sp in context.Spawns.AsNoTracking() on rp.ReplayPlayerId equals sp.ReplayPlayerId
+               join r in context.Replays.AsNoTracking() on rp.ReplayId equals r.ReplayId
+               join rr in context.ReplayRatings.AsNoTracking() on r.ReplayId equals rr.ReplayId
+               join rpr in context.ReplayPlayerRatings.AsNoTracking() on rp.ReplayPlayerId equals rpr.ReplayPlayerId
+               where rr.LeaverType == LeaverType.None
+               && rr.RatingType == request.RatingType
+               && rpr.RatingType == request.RatingType
+               && r.Gametime >= timeInfo.Start
+               && (!timeInfo.HasEnd || r.Gametime < timeInfo.End)
+               && rp.Race == request.Interest
+               && (request.Versus == Commander.None || rp.OppRace == request.Versus)
+               && (!noPlayers || request.FromRating <= Data.MinBuildRating || rpr.RatingBefore >= request.FromRating)
+               && (!noPlayers || request.ToRating >= Data.MaxBuildRating || rpr.RatingBefore <= request.ToRating)
+               && sp.Breakpoint == request.Breakpoint
+               && (noPlayers || playerIds.Contains(rp.PlayerId))
+               select rp;
+    }
+
+    private static int GetBreakpointSeconds(Breakpoint breakpoint)
+    {
+        return breakpoint switch
+        {
+            Breakpoint.Min5 => 5 * 60,
+            Breakpoint.Min10 => 10 * 60,
+            Breakpoint.Min15 => 15 * 60,
+            _ => int.MaxValue
+        };
+    }
+
+    private struct GasTimingAccumulator
+    {
+        public int Count;
+        public long TotalSeconds;
     }
 }

--- a/src/tests/dsstats.tests/BuildsService.Tests.cs
+++ b/src/tests/dsstats.tests/BuildsService.Tests.cs
@@ -1,0 +1,363 @@
+using dsstats.db;
+using dsstats.dbServices.Builds;
+using dsstats.shared;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace dsstats.tests;
+
+[TestClass]
+public sealed class BuildsServiceTests
+{
+    [TestMethod]
+    public async Task GetBuildResponse_AndUpgradeTimings_ReturnUpgradeSpendAndAverageTiming()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        for (var i = 0; i < 10; i++)
+        {
+            await fixture.SeedReplayPlayerAsync(
+                replayId: i + 1,
+                playerId: 101 + i,
+                commander: Commander.Abathur,
+                oppCommander: Commander.Alarak,
+                min5UpgradeSpent: i < 5 ? 100 : 300,
+                allUpgradeSpent: i < 5 ? 400 : 500,
+                min5GasCount: i < 5 ? 1 : 2,
+                allGasCount: 3,
+                refineries: [i < 5 ? 100 : 200, i < 5 ? 200 : 280, 400],
+                upgrades:
+                [
+                    ("BlinkTech", i < 5 ? 100 : 200),
+                    ("Charge", i < 5 ? 200 : 280),
+                    ("PlayerStateVictory", 250),
+                    ("LateUpgrade", 400)
+                ]);
+        }
+
+        for (var i = 0; i < 9; i++)
+        {
+            await fixture.AddUpgradeAsync(replayPlayerId: (i + 1) * 1000 + 1, upgradeName: "RareUpgrade", time: 120);
+        }
+
+        await fixture.SeedReplayPlayerAsync(
+            replayId: 11,
+            playerId: 111,
+            commander: Commander.Fenix,
+            oppCommander: Commander.Alarak,
+            min5UpgradeSpent: 900,
+            allUpgradeSpent: 900,
+            upgrades: [("IgnoredCommanderUpgrade", 120)]);
+
+        var request = CreateRequest(Breakpoint.Min5);
+        var response = await fixture.Service.GetBuildResponse(request);
+        var timings = await fixture.Service.GetUpgradeTimings(request);
+        var gasTimings = await fixture.Service.GetGasTimings(request);
+
+        Assert.AreEqual(1.5, response.Stats.Gas, 0.0001);
+        Assert.AreEqual(200.0, response.Stats.Upgrades, 0.0001);
+        Assert.AreEqual(2, timings.Count);
+
+        var blink = timings.Single(x => x.Upgrade == "BlinkTech");
+        Assert.AreEqual(150.0, blink.AverageTimeSeconds, 0.0001);
+        Assert.AreEqual(10, blink.Count);
+        Assert.AreEqual(100.0, blink.UsagePercent, 0.0001);
+
+        var charge = timings.Single(x => x.Upgrade == "Charge");
+        Assert.AreEqual(240.0, charge.AverageTimeSeconds, 0.0001);
+        Assert.AreEqual(10, charge.Count);
+        Assert.IsFalse(timings.Any(x => x.Upgrade.StartsWith("PlayerState")));
+        Assert.IsFalse(timings.Any(x => x.Upgrade == "LateUpgrade"));
+        Assert.IsFalse(timings.Any(x => x.Upgrade == "RareUpgrade"));
+
+        var allTimings = await fixture.Service.GetUpgradeTimings(CreateRequest(Breakpoint.All));
+        Assert.IsTrue(allTimings.Any(x => x.Upgrade == "LateUpgrade"));
+
+        Assert.AreEqual(2, gasTimings.Count);
+        Assert.AreEqual(150.0, gasTimings.Single(x => x.Gas == 1).AverageTimeSeconds, 0.0001);
+        Assert.AreEqual(240.0, gasTimings.Single(x => x.Gas == 2).AverageTimeSeconds, 0.0001);
+        Assert.AreEqual(10, gasTimings.Single(x => x.Gas == 1).Count);
+        Assert.IsFalse(gasTimings.Any(x => x.Gas == 3));
+
+        var allGasTimings = await fixture.Service.GetGasTimings(CreateRequest(Breakpoint.All));
+        Assert.IsTrue(allGasTimings.Any(x => x.Gas == 3));
+    }
+
+    [TestMethod]
+    public async Task GetUpgradeTimings_AppliesCommanderVersusPlayerRatingAndLeaverFilters()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        for (var i = 0; i < 10; i++)
+        {
+            await fixture.SeedReplayPlayerAsync(
+                replayId: 100 + i,
+                playerId: 201,
+                commander: Commander.Abathur,
+                oppCommander: Commander.Alarak,
+                ratingBefore: 1800,
+                refineries: [120],
+                upgrades: [("IncludedUpgrade", 120)]);
+            await fixture.SeedReplayPlayerAsync(
+                replayId: 200 + i,
+                playerId: 202 + i,
+                commander: Commander.Abathur,
+                oppCommander: Commander.Alarak,
+                ratingBefore: 900,
+                refineries: [120],
+                upgrades: [("LowRatingUpgrade", 120)]);
+            await fixture.SeedReplayPlayerAsync(
+                replayId: 300 + i,
+                playerId: 302 + i,
+                commander: Commander.Abathur,
+                oppCommander: Commander.Dehaka,
+                ratingBefore: 1800,
+                refineries: [120],
+                upgrades: [("WrongVersusUpgrade", 120)]);
+            await fixture.SeedReplayPlayerAsync(
+                replayId: 400 + i,
+                playerId: 402 + i,
+                commander: Commander.Abathur,
+                oppCommander: Commander.Alarak,
+                leaverType: LeaverType.OneLeaver,
+                ratingBefore: 1800,
+                refineries: [120],
+                upgrades: [("LeaverUpgrade", 120)]);
+            await fixture.SeedReplayPlayerAsync(
+                replayId: 500 + i,
+                playerId: 502 + i,
+                commander: Commander.Fenix,
+                oppCommander: Commander.Alarak,
+                ratingBefore: 1800,
+                refineries: [120],
+                upgrades: [("WrongCommanderUpgrade", 120)]);
+        }
+
+        var request = CreateRequest(Breakpoint.Min5);
+        request.Players = [CreatePlayerDto(201)];
+
+        var timings = await fixture.Service.GetUpgradeTimings(request);
+        var gasTimings = await fixture.Service.GetGasTimings(request);
+
+        Assert.AreEqual(1, timings.Count);
+        Assert.AreEqual("IncludedUpgrade", timings[0].Upgrade);
+        Assert.AreEqual(10, timings[0].Count);
+        Assert.AreEqual(100.0, timings[0].UsagePercent, 0.0001);
+        Assert.AreEqual(1, gasTimings.Count);
+        Assert.AreEqual(1, gasTimings[0].Gas);
+        Assert.AreEqual(10, gasTimings[0].Count);
+
+        var ratingRequest = CreateRequest(Breakpoint.Min5);
+        ratingRequest.FromRating = 1500;
+        ratingRequest.ToRating = 2000;
+
+        var ratingFilteredTimings = await fixture.Service.GetUpgradeTimings(ratingRequest);
+        var ratingFilteredGasTimings = await fixture.Service.GetGasTimings(ratingRequest);
+
+        Assert.AreEqual(1, ratingFilteredTimings.Count);
+        Assert.AreEqual("IncludedUpgrade", ratingFilteredTimings[0].Upgrade);
+        Assert.AreEqual(1, ratingFilteredGasTimings.Count);
+        Assert.AreEqual(1, ratingFilteredGasTimings[0].Gas);
+    }
+
+    private static BuildsRequest CreateRequest(Breakpoint breakpoint)
+    {
+        return new()
+        {
+            RatingType = RatingType.Commanders,
+            TimePeriod = TimePeriod.AllTime,
+            Interest = Commander.Abathur,
+            Versus = Commander.Alarak,
+            FromRating = Data.MinBuildRating,
+            ToRating = Data.MaxBuildRating,
+            Breakpoint = breakpoint,
+            WithSpawnInfo = false
+        };
+    }
+
+    private static PlayerDto CreatePlayerDto(int playerId)
+    {
+        return new()
+        {
+            PlayerId = playerId,
+            Name = $"Player{playerId}",
+            ToonId = new() { Region = 1, Realm = 1, Id = playerId }
+        };
+    }
+
+    private sealed class TestFixture : IAsyncDisposable
+    {
+        private readonly Dictionary<string, Upgrade> upgrades = [];
+
+        private TestFixture(SqliteConnection connection, DsstatsContext context, BuildsService service, IMemoryCache memoryCache)
+        {
+            Connection = connection;
+            Context = context;
+            Service = service;
+            MemoryCache = memoryCache;
+        }
+
+        public SqliteConnection Connection { get; }
+        public DsstatsContext Context { get; }
+        public BuildsService Service { get; }
+        public IMemoryCache MemoryCache { get; }
+
+        public static async Task<TestFixture> CreateAsync()
+        {
+            var connection = new SqliteConnection("Filename=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<DsstatsContext>()
+                .UseSqlite(connection, o => o.MigrationsAssembly("dsstats.migrations.sqlite"))
+                .Options;
+
+            var context = new DsstatsContext(options);
+            var contextFactory = new TestDbContextFactory<DsstatsContext>(options);
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.MigrateAsync();
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var service = new BuildsService(contextFactory, cache);
+            return new TestFixture(connection, context, service, cache);
+        }
+
+        public async Task SeedReplayPlayerAsync(
+            int replayId,
+            int playerId,
+            Commander commander,
+            Commander oppCommander,
+            int min5UpgradeSpent = 100,
+            int allUpgradeSpent = 100,
+            int min5GasCount = 0,
+            int allGasCount = 0,
+            double ratingBefore = 1800,
+            LeaverType leaverType = LeaverType.None,
+            RatingType ratingType = RatingType.Commanders,
+            int[]? refineries = null,
+            (string Upgrade, int Time)[]? upgrades = null)
+        {
+            upgrades ??= [];
+            refineries ??= [];
+
+            var replayPlayerId = replayId * 1000 + 1;
+            var replayRatingId = replayId * 10;
+            var player = Context.Players.Local.FirstOrDefault(x => x.PlayerId == playerId)
+                ?? await Context.Players.FindAsync(playerId);
+            var addPlayer = player is null;
+            player ??= new Player
+            {
+                PlayerId = playerId,
+                Name = $"Player{playerId}",
+                ToonId = new ToonId { Region = 1, Realm = 1, Id = playerId }
+            };
+            var replay = new Replay
+            {
+                ReplayId = replayId,
+                FileName = $"Replay-{replayId}.SC2Replay",
+                Title = $"Replay {replayId}",
+                Version = "1.0",
+                GameMode = GameMode.Commanders,
+                RegionId = 1,
+                TE = false,
+                PlayerCount = 6,
+                Gametime = new DateTime(2026, 1, 1).AddDays(replayId),
+                BaseBuild = 90000,
+                Duration = 900,
+                WinnerTeam = 1,
+                ReplayHash = $"hash-{replayId}",
+                CompatHash = $"compat-{replayId}",
+                Imported = new DateTime(2026, 1, 1).AddDays(replayId).AddMinutes(1),
+                Uploaded = true
+            };
+            var replayPlayer = new ReplayPlayer
+            {
+                ReplayPlayerId = replayPlayerId,
+                Name = player.Name,
+                Race = commander,
+                SelectedRace = commander,
+                OppRace = oppCommander,
+                TeamId = 1,
+                GamePos = 1,
+                Duration = replay.Duration,
+                Result = PlayerResult.Win,
+                ReplayId = replayId,
+                PlayerId = playerId,
+                Refineries = refineries,
+                Spawns =
+                [
+                    new() { Breakpoint = Breakpoint.Min5, GasCount = min5GasCount, UpgradeSpent = min5UpgradeSpent },
+                    new() { Breakpoint = Breakpoint.All, GasCount = allGasCount, UpgradeSpent = allUpgradeSpent }
+                ]
+            };
+
+            foreach (var upgrade in upgrades)
+            {
+                replayPlayer.Upgrades.Add(new PlayerUpgrade
+                {
+                    Gameloop = upgrade.Time,
+                    Upgrade = GetUpgrade(upgrade.Upgrade)
+                });
+            }
+
+            if (addPlayer)
+            {
+                Context.Players.Add(player);
+            }
+            Context.Replays.Add(replay);
+            Context.ReplayPlayers.Add(replayPlayer);
+            Context.ReplayRatings.Add(new ReplayRating
+            {
+                ReplayRatingId = replayRatingId,
+                RatingType = ratingType,
+                LeaverType = leaverType,
+                ExpectedWinProbability = 0.5,
+                AvgRating = 1800,
+                ReplayId = replayId
+            });
+            Context.ReplayPlayerRatings.Add(new ReplayPlayerRating
+            {
+                ReplayPlayerRatingId = replayId * 10000 + 1,
+                RatingType = ratingType,
+                RatingBefore = ratingBefore,
+                RatingDelta = 5,
+                ExpectedDelta = 0,
+                Games = 10,
+                ReplayRatingId = replayRatingId,
+                ReplayPlayerId = replayPlayerId,
+                PlayerId = playerId
+            });
+
+            await Context.SaveChangesAsync();
+        }
+
+        public async Task AddUpgradeAsync(int replayPlayerId, string upgradeName, int time)
+        {
+            var replayPlayer = Context.ReplayPlayers.Local.First(x => x.ReplayPlayerId == replayPlayerId);
+            replayPlayer.Upgrades.Add(new PlayerUpgrade
+            {
+                Gameloop = time,
+                Upgrade = GetUpgrade(upgradeName)
+            });
+
+            await Context.SaveChangesAsync();
+        }
+
+        private Upgrade GetUpgrade(string name)
+        {
+            if (upgrades.TryGetValue(name, out var upgrade))
+            {
+                return upgrade;
+            }
+
+            upgrade = new Upgrade { Name = name };
+            upgrades[name] = upgrade;
+            return upgrade;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            await Connection.DisposeAsync();
+            (MemoryCache as MemoryCache)?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Summary: add builds upgrade and gas timing endpoints, lazy-loaded sortable timing modals, upgrade top usage row accent highlighting, and red negative Avg Gain display. Validation: dotnet test src/tests/dsstats.tests/dsstats.tests.sln --filter FullyQualifiedName~Build; dotnet build src/server/dsstats.web/dsstats.web.csproj