### PR TITLE
Fix chart disposal during stats navigation

### DIFF
--- a/src/common/dsstats.weblib/Stats/CountComponent.razor
+++ b/src/common/dsstats.weblib/Stats/CountComponent.razor
@@ -1,6 +1,8 @@
 ﻿@using dsstats.shared
 @using dsstats.shared.Interfaces
 
+@implements IDisposable
+
 @inject IStatsService StatsService
 
 <div class="mb-1" style="max-width: 1000px;">
@@ -128,6 +130,8 @@
     CountChart? countChart;
     StatsRequestComponent? statsRequestComponent;
     bool isLoading = true;
+    private readonly CancellationTokenSource cts = new();
+    private bool disposed;
 
     private string? currentSortColumn = null;
     private bool isDescending = true;
@@ -161,33 +165,64 @@
 
     private async Task LoadData()
     {
+        var token = cts.Token;
         try
         {
-            response = await StatsService.GetStatsAsync<CountResponse>(StatsType.Count, StatsRequest);
+            response = await StatsService.GetStatsAsync<CountResponse>(StatsType.Count, StatsRequest, token);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
         }
         catch
         {
         }
         finally
         {
-            isLoading = false;
-            await InvokeAsync(StateHasChanged);
-            if (response != null)
+            if (!disposed && !token.IsCancellationRequested)
             {
-                countChart?.PrepareData(response, StatsRequest);
+                isLoading = false;
+                await InvokeAsync(StateHasChanged);
+                if (!disposed && response != null)
+                {
+                    countChart?.PrepareData(response, StatsRequest);
+                }
             }
         }
     }
 
     private async Task Update()
     {
+        if (disposed)
+        {
+            return;
+        }
+
+        var token = cts.Token;
         isLoading = true;
         await InvokeAsync(StateHasChanged);
-        response = await StatsService.GetStatsAsync<CountResponse>(StatsType.Count, StatsRequest);
-        countChart?.PrepareData(response, StatsRequest);
-        isLoading = false;
-        await InvokeAsync(StateHasChanged);
-        await OnRequestChanged.InvokeAsync(StatsRequest);
+        try
+        {
+            response = await StatsService.GetStatsAsync<CountResponse>(StatsType.Count, StatsRequest, token);
+            if (disposed || token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            countChart?.PrepareData(response, StatsRequest);
+            isLoading = false;
+            await InvokeAsync(StateHasChanged);
+            await OnRequestChanged.InvokeAsync(StatsRequest);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        disposed = true;
+        cts.Cancel();
+        cts.Dispose();
     }
 
     private bool IsStrongPlayerFilter => StatsRequest.Filter != null &&

--- a/src/common/dsstats.weblib/Stats/SynergyComponent.razor
+++ b/src/common/dsstats.weblib/Stats/SynergyComponent.razor
@@ -1,6 +1,8 @@
 @using dsstats.shared
 @using dsstats.shared.Interfaces
 
+@implements IDisposable
+
 @inject IStatsService StatsService
 
 <div class="mb-1" style="max-width: 1000px;">
@@ -206,6 +208,8 @@
     bool hasManualSelection;
     Commander previousInterest = Commander.None;
     HashSet<Commander> selectedCommanders = [];
+    private readonly CancellationTokenSource cts = new();
+    private bool disposed;
 
     private string? currentSortColumn = nameof(SynergyEnt.AvgGain);
     private bool isDescending = true;
@@ -261,27 +265,45 @@
 
     private async Task LoadData()
     {
+        var token = cts.Token;
         try
         {
-            response = await StatsService.GetStatsAsync<SynergyResponse>(StatsType.Synergy, StatsRequest);
+            response = await StatsService.GetStatsAsync<SynergyResponse>(StatsType.Synergy, StatsRequest, token);
+            if (disposed || token.IsCancellationRequested)
+            {
+                return;
+            }
+
             ApplyDefaultSelection(forceReset: true);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
         }
         catch
         {
         }
         finally
         {
-            isLoading = false;
-            await InvokeAsync(StateHasChanged);
-            if (response != null)
+            if (!disposed && !token.IsCancellationRequested)
             {
-                synergyChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
+                isLoading = false;
+                await InvokeAsync(StateHasChanged);
+                if (!disposed && response != null)
+                {
+                    synergyChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
+                }
             }
         }
     }
 
     private async Task Update()
     {
+        if (disposed)
+        {
+            return;
+        }
+
+        var token = cts.Token;
         isLoading = true;
         await InvokeAsync(StateHasChanged);
 
@@ -291,13 +313,31 @@
             hasManualSelection = false;
         }
 
-        response = await StatsService.GetStatsAsync<SynergyResponse>(StatsType.Synergy, StatsRequest);
-        previousInterest = StatsRequest.Interest;
-        ApplyDefaultSelection(forceReset: interestChanged);
-        synergyChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
-        isLoading = false;
-        await InvokeAsync(StateHasChanged);
-        await OnRequestChanged.InvokeAsync(StatsRequest);
+        try
+        {
+            response = await StatsService.GetStatsAsync<SynergyResponse>(StatsType.Synergy, StatsRequest, token);
+            if (disposed || token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            previousInterest = StatsRequest.Interest;
+            ApplyDefaultSelection(forceReset: interestChanged);
+            synergyChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
+            isLoading = false;
+            await InvokeAsync(StateHasChanged);
+            await OnRequestChanged.InvokeAsync(StatsRequest);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        disposed = true;
+        cts.Cancel();
+        cts.Dispose();
     }
 
     private void ApplyDefaultSelection(bool forceReset)

--- a/src/common/dsstats.weblib/Stats/TimelineComponent.razor
+++ b/src/common/dsstats.weblib/Stats/TimelineComponent.razor
@@ -1,6 +1,7 @@
 ﻿@using Microsoft.Extensions.Logging
 @using dsstats.shared
 @using dsstats.shared.Interfaces
+@implements IDisposable
 @inject ILogger<TimelineComponent> logger
 
 @inject IStatsService StatsService
@@ -113,6 +114,8 @@
     Commander previousInterest = Commander.None;
     HashSet<Commander> selectedCommanders = [];
     TimelineChart? timelineChart;
+    private readonly CancellationTokenSource cts = new();
+    private bool disposed;
     private int currentSortColumn = 0;
     private bool isDescending = false;
 
@@ -127,10 +130,19 @@
 
     private async Task LoadData()
     {
+        var token = cts.Token;
         try
         {
-            response = await StatsService.GetStatsAsync<TimelineResponse>(StatsType.Timeline, StatsRequest);
+            response = await StatsService.GetStatsAsync<TimelineResponse>(StatsType.Timeline, StatsRequest, token);
+            if (disposed || token.IsCancellationRequested)
+            {
+                return;
+            }
+
             ApplyDefaultSelection(forceReset: true);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
@@ -138,17 +150,26 @@
         }
         finally
         {
-            isLoading = false;
-            await InvokeAsync(StateHasChanged);
-            if (response != null)
+            if (!disposed && !token.IsCancellationRequested)
             {
-                timelineChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
+                isLoading = false;
+                await InvokeAsync(StateHasChanged);
+                if (!disposed && response != null)
+                {
+                    timelineChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
+                }
             }
         }
     }
 
     private async Task Update()
     {
+        if (disposed)
+        {
+            return;
+        }
+
+        var token = cts.Token;
         isLoading = true;
         await InvokeAsync(StateHasChanged);
 
@@ -158,13 +179,31 @@
             hasManualSelection = false;
         }
 
-        response = await StatsService.GetStatsAsync<TimelineResponse>(StatsType.Timeline, StatsRequest);
-        previousInterest = StatsRequest.Interest;
-        ApplyDefaultSelection(forceReset: interestChanged);
-        timelineChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
-        isLoading = false;
-        await InvokeAsync(StateHasChanged);
-        await OnRequestChanged.InvokeAsync(StatsRequest);
+        try
+        {
+            response = await StatsService.GetStatsAsync<TimelineResponse>(StatsType.Timeline, StatsRequest, token);
+            if (disposed || token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            previousInterest = StatsRequest.Interest;
+            ApplyDefaultSelection(forceReset: interestChanged);
+            timelineChart?.PrepareData(response, StatsRequest, selectedCommanders.ToList());
+            isLoading = false;
+            await InvokeAsync(StateHasChanged);
+            await OnRequestChanged.InvokeAsync(StatsRequest);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        disposed = true;
+        cts.Cancel();
+        cts.Dispose();
     }
 
     private void ApplyDefaultSelection(bool forceReset)

--- a/src/common/dsstats.weblib/Stats/WinrateComponent.razor
+++ b/src/common/dsstats.weblib/Stats/WinrateComponent.razor
@@ -1,6 +1,8 @@
 ﻿@using dsstats.shared
 @using dsstats.shared.Interfaces
 
+@implements IDisposable
+
 @inject IStatsService StatsService
 
 <div class="mb-1" style="max-width: 1000px;">
@@ -102,6 +104,8 @@
     StatsRequestComponent? statsRequestComponent;
     bool isLoading = true;
     bool showSampleSizeWarning = false;
+    private readonly CancellationTokenSource cts = new();
+    private bool disposed;
 
     private string? currentSortColumn = null;
     private bool isDescending = true;
@@ -141,34 +145,65 @@
 
     private async Task LoadData()
     {
+        var token = cts.Token;
         try
         {
-            response = await StatsService.GetStatsAsync<WinrateResponse>(StatsType.Winrate, StatsRequest);
+            response = await StatsService.GetStatsAsync<WinrateResponse>(StatsType.Winrate, StatsRequest, token);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
         }
         catch
         {
         }
         finally
         {
-            isLoading = false;
-            await InvokeAsync(StateHasChanged);
-            if (response != null)
+            if (!disposed && !token.IsCancellationRequested)
             {
-                winrateChart?.PrepareData(response, StatsRequest);
+                isLoading = false;
+                await InvokeAsync(StateHasChanged);
+                if (!disposed && response != null)
+                {
+                    winrateChart?.PrepareData(response, StatsRequest);
+                }
             }
         }
     }
 
     private async Task Update()
     {
+        if (disposed)
+        {
+            return;
+        }
+
+        var token = cts.Token;
         isLoading = true;
         await InvokeAsync(StateHasChanged);
-        response = await StatsService.GetStatsAsync<WinrateResponse>(StatsType.Winrate, StatsRequest);
-        winrateChart?.PrepareData(response, StatsRequest);
-        isLoading = false;
-        showSampleSizeWarning = response.WinrateEnts.Any(a => a.Count < 100);
-        await InvokeAsync(StateHasChanged);
-        await OnRequestChanged.InvokeAsync(StatsRequest);
+        try
+        {
+            response = await StatsService.GetStatsAsync<WinrateResponse>(StatsType.Winrate, StatsRequest, token);
+            if (disposed || token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            winrateChart?.PrepareData(response, StatsRequest);
+            isLoading = false;
+            showSampleSizeWarning = response.WinrateEnts.Any(a => a.Count < 100);
+            await InvokeAsync(StateHasChanged);
+            await OnRequestChanged.InvokeAsync(StatsRequest);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        disposed = true;
+        cts.Cancel();
+        cts.Dispose();
     }
 
     private bool IsStrongPlayerFilter => StatsRequest.Filter != null &&

--- a/src/common/dsstats.weblib/dsstats.weblib.csproj
+++ b/src/common/dsstats.weblib/dsstats.weblib.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.*" />
-    <PackageReference Include="pax.BlazorChartJs" Version="0.8.7" />
+    <PackageReference Include="pax.BlazorChartJs" Version="0.8.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update dsstats.weblib to pax.BlazorChartJs 0.8.8
- cancel in-flight stats loads when stats components are disposed
- skip chart updates and render refreshes after navigation/disposal

## Root Cause
Stats pages could complete async data loading after the chart component had already been disposed during navigation. That could trigger stale Chart.js interop calls.

## Validation
- dotnet build src/server/server.sln