### PR TITLE
[codex] add standard race roster build details

### DIFF
--- a/src/common/dsstats.shared/BuildDetailsRequest.cs
+++ b/src/common/dsstats.shared/BuildDetailsRequest.cs
@@ -17,6 +17,13 @@ public enum BuildDetailsTeFilter
     NonTE = 2,
 }
 
+public enum BuildDetailsTab
+{
+    BuildDetails = 0,
+    TeamBuilds = 1,
+    RaceRosters = 2,
+}
+
 public class BuildDetailsRequest
 {
     public RatingType RatingType { get; set; } = RatingType.All;
@@ -46,6 +53,21 @@ public sealed class BuildDetailsSamplesRequest : BuildDetailsMatchupRequest
 public sealed class BuildDetailsTeamBuildSamplesRequest : BuildDetailsRequest
 {
     public TeamBuild SelectedTeamBuild { get; set; }
+    public int Count { get; set; } = 10;
+}
+
+public class BuildDetailsRaceRosterMatchupRequest : BuildDetailsRequest
+{
+    public Commander Race1 { get; set; }
+    public Commander Race2 { get; set; }
+    public Commander Race3 { get; set; }
+}
+
+public sealed class BuildDetailsRaceRosterSamplesRequest : BuildDetailsRaceRosterMatchupRequest
+{
+    public Commander OpponentRace1 { get; set; }
+    public Commander OpponentRace2 { get; set; }
+    public Commander OpponentRace3 { get; set; }
     public int Count { get; set; } = 10;
 }
 
@@ -114,6 +136,44 @@ public sealed class BuildDetailsTeamBuildSampleReplay
     public double FollowerGain { get; set; }
 }
 
+public sealed class BuildDetailsRaceRosterOverviewRow
+{
+    public Commander Race1 { get; set; }
+    public Commander Race2 { get; set; }
+    public Commander Race3 { get; set; }
+    public int Games { get; set; }
+    public int Wins { get; set; }
+    public double AverageRatingGain { get; set; }
+    public double Winrate { get; set; }
+    public double AverageRating { get; set; }
+}
+
+public sealed class BuildDetailsRaceRosterMatchupRow
+{
+    public Commander Race1 { get; set; }
+    public Commander Race2 { get; set; }
+    public Commander Race3 { get; set; }
+    public Commander OpponentRace1 { get; set; }
+    public Commander OpponentRace2 { get; set; }
+    public Commander OpponentRace3 { get; set; }
+    public int Games { get; set; }
+    public int Wins { get; set; }
+    public double AverageRatingGain { get; set; }
+    public double Winrate { get; set; }
+    public double AverageRating { get; set; }
+}
+
+public sealed class BuildDetailsRaceRosterSampleReplay
+{
+    public ReplayListDto Replay { get; set; } = new();
+    public Commander Race1 { get; set; }
+    public Commander Race2 { get; set; }
+    public Commander Race3 { get; set; }
+    public Commander OpponentRace1 { get; set; }
+    public Commander OpponentRace2 { get; set; }
+    public Commander OpponentRace3 { get; set; }
+}
+
 public static class BuildDetailsRequestExtensions
 {
     public static string GetMemKey(this BuildDetailsRequest request)
@@ -135,6 +195,16 @@ public static class BuildDetailsRequestExtensions
     public static string GetMemKey(this BuildDetailsTeamBuildSamplesRequest request)
     {
         return $"{((BuildDetailsRequest)request).GetMemKey()}_{request.SelectedTeamBuild}_{request.Count}";
+    }
+
+    public static string GetMemKey(this BuildDetailsRaceRosterMatchupRequest request)
+    {
+        return $"{((BuildDetailsRequest)request).GetMemKey()}_{request.Race1}_{request.Race2}_{request.Race3}";
+    }
+
+    public static string GetMemKey(this BuildDetailsRaceRosterSamplesRequest request)
+    {
+        return $"{((BuildDetailsRaceRosterMatchupRequest)request).GetMemKey()}_{request.OpponentRace1}_{request.OpponentRace2}_{request.OpponentRace3}_{request.Count}";
     }
 
     public static string GetBuildName(this BuildDetailsOverviewRow row)
@@ -162,6 +232,36 @@ public static class BuildDetailsRequestExtensions
         return GetBuildName(row.FollowerCommander, row.FollowerBuild);
     }
 
+    public static string GetRosterName(this BuildDetailsRaceRosterOverviewRow row)
+    {
+        return GetRosterName(row.Race1, row.Race2, row.Race3);
+    }
+
+    public static string GetRosterName(this BuildDetailsRaceRosterMatchupRow row)
+    {
+        return GetRosterName(row.Race1, row.Race2, row.Race3);
+    }
+
+    public static string GetOpponentRosterName(this BuildDetailsRaceRosterMatchupRow row)
+    {
+        return GetRosterName(row.OpponentRace1, row.OpponentRace2, row.OpponentRace3);
+    }
+
+    public static string GetRosterName(this BuildDetailsRaceRosterSampleReplay row)
+    {
+        return GetRosterName(row.Race1, row.Race2, row.Race3);
+    }
+
+    public static string GetOpponentRosterName(this BuildDetailsRaceRosterSampleReplay row)
+    {
+        return GetRosterName(row.OpponentRace1, row.OpponentRace2, row.OpponentRace3);
+    }
+
+    public static string GetRosterName(Commander race1, Commander race2, Commander race3)
+    {
+        return $"{race1}, {race2}, {race3}";
+    }
+
     public static string GetBuildName(Commander commander, int build)
     {
         return commander switch
@@ -187,6 +287,17 @@ public static class BuildDetailsRequestExtensions
     }
 
     public static string GetReplayLink(this BuildDetailsTeamBuildSamplesRequest request)
+    {
+        var sb = new StringBuilder();
+        sb.Append("replays?");
+        if (request.Player is not null)
+        {
+            sb.Append($"ToonIds={Uri.EscapeDataString(Data.GetToonIdString(request.Player.ToonId))}");
+        }
+        return sb.ToString();
+    }
+
+    public static string GetReplayLink(this BuildDetailsRaceRosterSamplesRequest request)
     {
         var sb = new StringBuilder();
         sb.Append("replays?");

--- a/src/common/dsstats.shared/Interfaces/IBuildDetailsService.cs
+++ b/src/common/dsstats.shared/Interfaces/IBuildDetailsService.cs
@@ -7,4 +7,7 @@ public interface IBuildDetailsService
     Task<List<BuildDetailsSampleReplay>> GetSampleReplays(BuildDetailsSamplesRequest request, CancellationToken token = default);
     Task<List<BuildDetailsTeamBuildOverviewRow>> GetTeamBuildOverview(BuildDetailsRequest request, CancellationToken token = default);
     Task<List<BuildDetailsTeamBuildSampleReplay>> GetTeamBuildSampleReplays(BuildDetailsTeamBuildSamplesRequest request, CancellationToken token = default);
+    Task<List<BuildDetailsRaceRosterOverviewRow>> GetRaceRosterOverview(BuildDetailsRequest request, CancellationToken token = default);
+    Task<List<BuildDetailsRaceRosterMatchupRow>> GetRaceRosterMatchups(BuildDetailsRaceRosterMatchupRequest request, CancellationToken token = default);
+    Task<List<BuildDetailsRaceRosterSampleReplay>> GetRaceRosterSampleReplays(BuildDetailsRaceRosterSamplesRequest request, CancellationToken token = default);
 }

--- a/src/common/dsstats.weblib/BuildDetails/BuildDetailsComponent.razor
+++ b/src/common/dsstats.weblib/BuildDetails/BuildDetailsComponent.razor
@@ -34,6 +34,13 @@
                         Team Builds
                     </button>
                 </li>
+                <li class="nav-item">
+                    <button type="button"
+                            class="nav-link @(activeTab == BuildDetailsTab.RaceRosters ? "active" : "")"
+                            @onclick="() => SetActiveTab(BuildDetailsTab.RaceRosters)">
+                        Race Rosters
+                    </button>
+                </li>
             </ul>
         </div>
     </div>
@@ -349,9 +356,13 @@
         </div>
     </div>
     }
-    else
+    else if (activeTab == BuildDetailsTab.TeamBuilds)
     {
         <TeamBuildDetailsComponent Request="Request" RequestVersion="requestVersion" />
+    }
+    else
+    {
+        <RaceRosterDetailsComponent Request="Request" RequestVersion="requestVersion" />
     }
 </div>
 
@@ -366,6 +377,12 @@
 
     [Parameter]
     public EventCallback<BuildDetailsRequest> OnRequestChanged { get; set; }
+
+    [Parameter]
+    public BuildDetailsTab ActiveTab { get; set; } = BuildDetailsTab.BuildDetails;
+
+    [Parameter]
+    public EventCallback<BuildDetailsTab> OnActiveTabChanged { get; set; }
 
     private EditContext editContext = null!;
     private readonly CancellationTokenSource cts = new();
@@ -386,6 +403,7 @@
     private bool showMatchupAnecdotalResults;
     private int requestVersion;
     private BuildDetailsTab activeTab = BuildDetailsTab.BuildDetails;
+    private bool initialized;
     private readonly List<TableOrder> overviewOrders = [new() { Column = nameof(BuildDetailsOverviewRow.AverageRatingGain), Ascending = false }];
     private readonly List<TableOrder> matchupOrders = [new() { Column = nameof(BuildDetailsMatchupRow.AverageRatingGain), Ascending = false }];
     private const int AdjustedGainK = 20;
@@ -440,7 +458,18 @@
     {
         editContext = new(Request);
         editContext.OnFieldChanged += FieldChanged;
+        activeTab = ActiveTab;
+        initialized = true;
         await ReloadCurrentTab(true);
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (initialized && activeTab != ActiveTab)
+        {
+            activeTab = ActiveTab;
+            await ReloadCurrentTab(true);
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -507,9 +536,15 @@
         }
     }
 
-    private void SetActiveTab(BuildDetailsTab tab)
+    private async Task SetActiveTab(BuildDetailsTab tab)
     {
+        if (activeTab == tab)
+        {
+            return;
+        }
+
         activeTab = tab;
+        await OnActiveTabChanged.InvokeAsync(tab);
     }
 
     private async Task LoadMatchups(BuildDetailsOverviewRow row)
@@ -827,11 +862,5 @@
         editContext.OnFieldChanged -= FieldChanged;
         cts.Cancel();
         cts.Dispose();
-    }
-
-    private enum BuildDetailsTab
-    {
-        BuildDetails,
-        TeamBuilds,
     }
 }

--- a/src/common/dsstats.weblib/BuildDetails/RaceRosterDetailsComponent.razor
+++ b/src/common/dsstats.weblib/BuildDetails/RaceRosterDetailsComponent.razor
@@ -1,0 +1,575 @@
+@using dsstats.shared
+@using dsstats.shared.Interfaces
+@using dsstats.weblib.Players
+@using dsstats.weblib.Replays
+@inject IBuildDetailsService BuildDetailsService
+@inject IReplayRepository ReplayRepository
+@implements IDisposable
+
+<div class="row g-2">
+    <div class="col-xxl-4 col-xl-6 col-lg-12">
+        <div class="bgchart border rounded p-2 h-100">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <h4 class="mb-0">Race Rosters</h4>
+                <div class="d-flex align-items-center gap-3">
+                    <div class="form-check form-switch mb-0">
+                        <input id="raceRosterShowAnecdotalOverview" type="checkbox" class="form-check-input"
+                               checked="@showOverviewAnecdotalResults" @onchange="ShowOverviewAnecdotalChanged" />
+                        <label for="raceRosterShowAnecdotalOverview" class="form-check-label small">Show anecdotal results</label>
+                    </div>
+                    @if (overviewLoading)
+                    {
+                        <div class="spinner-border spinner-border-sm" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    }
+                </div>
+            </div>
+            <div class="table-responsive" style="max-height: 67vh; overflow-y: auto;">
+                <table class="tptable">
+                    <CascadingValue Value="overviewOrders">
+                        <thead class="user-select-none">
+                            <tr>
+                                <th class="pointer" style="width: 190px;" @onclick="e => SortOverview(nameof(BuildDetailsRaceRosterOverviewRow.Race1))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterOverviewRow.Race1)">Roster</SortArrow>
+                                </th>
+                                <th class="pointer text-end" style="width: 90px;" @onclick="e => SortOverview(nameof(BuildDetailsRaceRosterOverviewRow.AverageRatingGain))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterOverviewRow.AverageRatingGain)">Avg Gain</SortArrow>
+                                </th>
+                                <th class="pointer text-end" style="width: 80px;" @onclick="e => SortOverview(nameof(BuildDetailsRaceRosterOverviewRow.Winrate))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterOverviewRow.Winrate)">Winrate</SortArrow>
+                                </th>
+                                <th class="pointer text-end" style="width: 80px;" @onclick="e => SortOverview(nameof(BuildDetailsRaceRosterOverviewRow.Games))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterOverviewRow.Games)">Count</SortArrow>
+                                </th>
+                                <th class="text-end" style="width: 90px;">Confidence</th>
+                            </tr>
+                        </thead>
+                    </CascadingValue>
+                    <tbody class="text-nowrap">
+                        @if (overviewRows.Count == 0 && !overviewLoading)
+                        {
+                            <tr>
+                                <td colspan="100">No race roster details found.</td>
+                            </tr>
+                        }
+                        else if (VisibleOverviewCount == 0 && !overviewLoading)
+                        {
+                            <tr>
+                                <td colspan="100">Only anecdotal results found. Enable "Show anecdotal results" to view them.</td>
+                            </tr>
+                        }
+                        @foreach (var row in SortedOverviewRows)
+                        {
+                            <tr class="pointer @(IsSelectedOverview(row) ? "table-active" : "")" @onclick="() => SelectOverview(row)">
+                                <td>
+                                    <RaceRosterIcons Race1="row.Race1" Race2="row.Race2" Race3="row.Race3" />
+                                </td>
+                                <td class="text-end @GetGainClass(row.AverageRatingGain)">@row.AverageRatingGain.ToString("N2")</td>
+                                <td class="text-end">@row.Winrate.ToString("N1")%</td>
+                                <td class="text-end">@row.Games.ToString("N0")</td>
+                                <td class="text-end">@GetConfidenceLabel(row.Games)</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+            <div class="small text-muted mt-2">
+                Rosters are ordered by spawn position. Avg Gain is the average rating gain of the three team players.
+            </div>
+        </div>
+    </div>
+
+    <div class="col-xxl-4 col-xl-6 col-lg-12">
+        <div class="bgchart border rounded p-2 h-100">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <div>
+                    <h4 class="mb-0">
+                        @if (selectedOverview is null)
+                        {
+                            <span>Roster Matchups</span>
+                        }
+                        else
+                        {
+                            <RaceRosterIcons Race1="selectedOverview.Race1" Race2="selectedOverview.Race2" Race3="selectedOverview.Race3" />
+                        }
+                    </h4>
+                    <div class="small text-muted">Success vs other team roster</div>
+                </div>
+                <div class="d-flex align-items-center gap-3">
+                    <div class="form-check form-switch mb-0">
+                        <input id="raceRosterShowAnecdotalMatchups" type="checkbox" class="form-check-input"
+                               checked="@showMatchupAnecdotalResults" @onchange="ShowMatchupAnecdotalChanged" />
+                        <label for="raceRosterShowAnecdotalMatchups" class="form-check-label small">Show anecdotal results</label>
+                    </div>
+                    @if (matchupsLoading)
+                    {
+                        <div class="spinner-border spinner-border-sm" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    }
+                </div>
+            </div>
+            <div class="table-responsive" style="max-height: 67vh; overflow-y: auto;">
+                <table class="tptable">
+                    <CascadingValue Value="matchupOrders">
+                        <thead class="user-select-none">
+                            <tr>
+                                <th class="pointer" style="width: 190px;" @onclick="e => SortMatchups(nameof(BuildDetailsRaceRosterMatchupRow.OpponentRace1))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterMatchupRow.OpponentRace1)">Vs Roster</SortArrow>
+                                </th>
+                                <th class="pointer text-end" style="width: 90px;" @onclick="e => SortMatchups(nameof(BuildDetailsRaceRosterMatchupRow.AverageRatingGain))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterMatchupRow.AverageRatingGain)">Avg Gain</SortArrow>
+                                </th>
+                                <th class="pointer text-end" style="width: 80px;" @onclick="e => SortMatchups(nameof(BuildDetailsRaceRosterMatchupRow.Winrate))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterMatchupRow.Winrate)">Winrate</SortArrow>
+                                </th>
+                                <th class="pointer text-end" style="width: 80px;" @onclick="e => SortMatchups(nameof(BuildDetailsRaceRosterMatchupRow.Games))">
+                                    <SortArrow Column="@nameof(BuildDetailsRaceRosterMatchupRow.Games)">Count</SortArrow>
+                                </th>
+                                <th class="text-end" style="width: 90px;">Confidence</th>
+                            </tr>
+                        </thead>
+                    </CascadingValue>
+                    <tbody class="text-nowrap">
+                        @if (matchupRows.Count == 0 && !matchupsLoading)
+                        {
+                            <tr>
+                                <td colspan="100">No race roster matchup details found.</td>
+                            </tr>
+                        }
+                        else if (VisibleMatchupCount == 0 && !matchupsLoading)
+                        {
+                            <tr>
+                                <td colspan="100">Only anecdotal results found. Enable "Show anecdotal results" to view them.</td>
+                            </tr>
+                        }
+                        @foreach (var row in SortedMatchupRows)
+                        {
+                            <tr class="pointer @(IsSelectedMatchup(row) ? "table-active" : "")" @onclick="() => SelectMatchup(row)">
+                                <td>
+                                    <RaceRosterIcons Race1="row.OpponentRace1" Race2="row.OpponentRace2" Race3="row.OpponentRace3" />
+                                </td>
+                                <td class="text-end @GetGainClass(row.AverageRatingGain)">@row.AverageRatingGain.ToString("N2")</td>
+                                <td class="text-end">@row.Winrate.ToString("N1")%</td>
+                                <td class="text-end">@row.Games.ToString("N0")</td>
+                                <td class="text-end">@GetConfidenceLabel(row.Games)</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+            <div class="small text-muted mt-2">
+                Confidence: Very Low &lt; 5 games, Low 5-19, Medium 20-99, High 100+.
+            </div>
+        </div>
+    </div>
+
+    <div class="col-xxl-4 col-xl-12">
+        <div class="bgchart border rounded p-2 h-100">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <div>
+                    <h4 class="mb-0">Sample Replays</h4>
+                    @if (selectedMatchup is not null)
+                    {
+                        <div class="small text-muted">
+                            <RaceRosterIcons Race1="selectedMatchup.Race1" Race2="selectedMatchup.Race2" Race3="selectedMatchup.Race3" />
+                            <span class="text-danger"> vs </span>
+                            <RaceRosterIcons Race1="selectedMatchup.OpponentRace1" Race2="selectedMatchup.OpponentRace2" Race3="selectedMatchup.OpponentRace3" />
+                        </div>
+                    }
+                </div>
+                @if (samplesLoading)
+                {
+                    <div class="spinner-border spinner-border-sm" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                }
+            </div>
+            <div class="table-responsive" style="max-height: 67vh; overflow-y: auto;">
+                <table class="tptable">
+                    <thead>
+                        <tr>
+                            <th style="width: 24px;"></th>
+                            <th style="width: 100px;">Date</th>
+                            <th style="width: 80px;" class="text-end">Gain</th>
+                            <th style="width: 80px;" class="text-end">Rating</th>
+                            <th style="width: 190px;">Roster</th>
+                        </tr>
+                    </thead>
+                    <tbody class="text-nowrap">
+                        @if (sampleRows.Count == 0 && !samplesLoading)
+                        {
+                            <tr>
+                                <td colspan="100">Select a roster matchup.</td>
+                            </tr>
+                        }
+                        @foreach (var sample in sampleRows)
+                        {
+                            <tr class="pointer" @onclick="() => LoadReplayDetails(sample.Replay.ReplayHash)">
+                                <td>
+                                    <span class="bi bi-window-fullscreen text-primary"></span>
+                                </td>
+                                <td>@sample.Replay.Gametime.ToString("yyyy-MM-dd")</td>
+                                <td class="text-end @GetGainClass(sample.Replay.PlayerGain)">@sample.Replay.PlayerGain.ToString("N2")</td>
+                                <td class="text-end">@sample.Replay.AvgRating</td>
+                                <td>
+                                    <RaceRosterIcons Race1="sample.Race1" Race2="sample.Race2" Race3="sample.Race3" />
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                    @if (SelectedSamplesRequest is not null && sampleRows.Count > 0)
+                    {
+                        <tfoot>
+                            <tr>
+                                <td colspan="100" class="text-end"><a class="text-decoration-none" href="@SelectedSamplesRequest.GetReplayLink()">View replays</a></td>
+                            </tr>
+                        </tfoot>
+                    }
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<ReplayModal @ref="replayModal" IsCloseable="true" IsScrollable="true" OnPlayerRequest="e => playerModal?.Show(e)" OnClose="CloseReplay" />
+<PlayerModal @ref="playerModal" OnClose="e => replayModal?.Show(replayDetails!)" />
+
+@code {
+    [Parameter, EditorRequired]
+    public BuildDetailsRequest Request { get; set; } = default!;
+
+    [Parameter]
+    public int RequestVersion { get; set; }
+
+    private readonly CancellationTokenSource cts = new();
+    private readonly List<TableOrder> overviewOrders = [new() { Column = nameof(BuildDetailsRaceRosterOverviewRow.AverageRatingGain), Ascending = false }];
+    private readonly List<TableOrder> matchupOrders = [new() { Column = nameof(BuildDetailsRaceRosterMatchupRow.AverageRatingGain), Ascending = false }];
+    private List<BuildDetailsRaceRosterOverviewRow> overviewRows = [];
+    private List<BuildDetailsRaceRosterMatchupRow> matchupRows = [];
+    private List<BuildDetailsRaceRosterSampleReplay> sampleRows = [];
+    private BuildDetailsRaceRosterOverviewRow? selectedOverview;
+    private BuildDetailsRaceRosterMatchupRow? selectedMatchup;
+    private ReplayModal? replayModal;
+    private PlayerModal? playerModal;
+    private ReplayDetails? replayDetails;
+    private bool overviewLoading;
+    private bool matchupsLoading;
+    private bool samplesLoading;
+    private bool showOverviewAnecdotalResults;
+    private bool showMatchupAnecdotalResults;
+    private int loadedRequestVersion = -1;
+    private const int AnecdotalGameThreshold = 5;
+
+    private BuildDetailsRaceRosterSamplesRequest? SelectedSamplesRequest => selectedOverview is null || selectedMatchup is null
+        ? null
+        : CreateSamplesRequest(selectedOverview, selectedMatchup);
+
+    private int VisibleOverviewCount => showOverviewAnecdotalResults
+        ? overviewRows.Count
+        : overviewRows.Count(x => x.Games >= AnecdotalGameThreshold);
+
+    private IEnumerable<BuildDetailsRaceRosterOverviewRow> VisibleOverviewRows => showOverviewAnecdotalResults
+        ? overviewRows
+        : overviewRows.Where(x => x.Games >= AnecdotalGameThreshold);
+
+    private IEnumerable<BuildDetailsRaceRosterOverviewRow> SortedOverviewRows => overviewOrders[0].Column switch
+    {
+        nameof(BuildDetailsRaceRosterOverviewRow.Race1) => ApplyOverviewDirection(VisibleOverviewRows.OrderBy(x => x.GetRosterName())),
+        nameof(BuildDetailsRaceRosterOverviewRow.Winrate) => ApplyOverviewDirection(VisibleOverviewRows.OrderBy(x => x.Winrate).ThenByDescending(x => x.Games)),
+        nameof(BuildDetailsRaceRosterOverviewRow.Games) => ApplyOverviewDirection(VisibleOverviewRows.OrderBy(x => x.Games).ThenBy(x => x.GetRosterName())),
+        _ => ApplyOverviewDirection(VisibleOverviewRows.OrderBy(x => x.AverageRatingGain).ThenBy(x => x.Games)),
+    };
+
+    private int VisibleMatchupCount => showMatchupAnecdotalResults
+        ? matchupRows.Count
+        : matchupRows.Count(x => x.Games >= AnecdotalGameThreshold);
+
+    private IEnumerable<BuildDetailsRaceRosterMatchupRow> VisibleMatchupRows => showMatchupAnecdotalResults
+        ? matchupRows
+        : matchupRows.Where(x => x.Games >= AnecdotalGameThreshold);
+
+    private IEnumerable<BuildDetailsRaceRosterMatchupRow> SortedMatchupRows => matchupOrders[0].Column switch
+    {
+        nameof(BuildDetailsRaceRosterMatchupRow.OpponentRace1) => ApplyMatchupDirection(VisibleMatchupRows.OrderBy(x => x.GetOpponentRosterName())),
+        nameof(BuildDetailsRaceRosterMatchupRow.Winrate) => ApplyMatchupDirection(VisibleMatchupRows.OrderBy(x => x.Winrate).ThenByDescending(x => x.Games)),
+        nameof(BuildDetailsRaceRosterMatchupRow.Games) => ApplyMatchupDirection(VisibleMatchupRows.OrderBy(x => x.Games).ThenBy(x => x.GetOpponentRosterName())),
+        _ => ApplyMatchupDirection(VisibleMatchupRows.OrderBy(x => x.AverageRatingGain).ThenBy(x => x.Games)),
+    };
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (loadedRequestVersion != RequestVersion)
+        {
+            loadedRequestVersion = RequestVersion;
+            await LoadOverview();
+        }
+    }
+
+    private async Task LoadOverview()
+    {
+        overviewLoading = true;
+        matchupsLoading = true;
+        samplesLoading = true;
+        matchupRows = [];
+        sampleRows = [];
+        selectedOverview = null;
+        selectedMatchup = null;
+        await InvokeAsync(StateHasChanged);
+
+        overviewRows = await BuildDetailsService.GetRaceRosterOverview(Request, cts.Token);
+        selectedOverview = SortedOverviewRows.FirstOrDefault();
+        overviewLoading = false;
+        await InvokeAsync(StateHasChanged);
+
+        if (selectedOverview is not null)
+        {
+            await LoadMatchups(selectedOverview);
+        }
+        else
+        {
+            matchupsLoading = false;
+            samplesLoading = false;
+        }
+    }
+
+    private async Task LoadMatchups(BuildDetailsRaceRosterOverviewRow row)
+    {
+        matchupsLoading = true;
+        samplesLoading = true;
+        matchupRows = [];
+        sampleRows = [];
+        selectedMatchup = null;
+        await InvokeAsync(StateHasChanged);
+
+        matchupRows = await BuildDetailsService.GetRaceRosterMatchups(CreateMatchupRequest(row), cts.Token);
+        selectedMatchup = SortedMatchupRows.FirstOrDefault();
+        matchupsLoading = false;
+        await InvokeAsync(StateHasChanged);
+
+        if (selectedMatchup is not null)
+        {
+            await LoadSamples(row, selectedMatchup);
+        }
+        else
+        {
+            samplesLoading = false;
+        }
+    }
+
+    private async Task LoadSamples(BuildDetailsRaceRosterOverviewRow overview, BuildDetailsRaceRosterMatchupRow matchup)
+    {
+        samplesLoading = true;
+        sampleRows = [];
+        await InvokeAsync(StateHasChanged);
+
+        sampleRows = await BuildDetailsService.GetRaceRosterSampleReplays(CreateSamplesRequest(overview, matchup), cts.Token);
+        samplesLoading = false;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task SelectOverview(BuildDetailsRaceRosterOverviewRow row)
+    {
+        selectedOverview = row;
+        await LoadMatchups(row);
+    }
+
+    private async Task SelectMatchup(BuildDetailsRaceRosterMatchupRow row)
+    {
+        if (selectedOverview is null)
+        {
+            return;
+        }
+
+        selectedMatchup = row;
+        await LoadSamples(selectedOverview, row);
+    }
+
+    private async Task ShowOverviewAnecdotalChanged(ChangeEventArgs e)
+    {
+        showOverviewAnecdotalResults = e.Value is bool value && value;
+
+        if (selectedOverview is null || !IsOverviewVisible(selectedOverview))
+        {
+            selectedOverview = SortedOverviewRows.FirstOrDefault();
+            matchupRows = [];
+            sampleRows = [];
+            selectedMatchup = null;
+
+            if (selectedOverview is not null)
+            {
+                await LoadMatchups(selectedOverview);
+            }
+            else
+            {
+                matchupsLoading = false;
+                samplesLoading = false;
+            }
+        }
+    }
+
+    private async Task ShowMatchupAnecdotalChanged(ChangeEventArgs e)
+    {
+        showMatchupAnecdotalResults = e.Value is bool value && value;
+
+        if (selectedOverview is null)
+        {
+            return;
+        }
+
+        if (selectedMatchup is null || !IsMatchupVisible(selectedMatchup))
+        {
+            selectedMatchup = SortedMatchupRows.FirstOrDefault();
+            sampleRows = [];
+
+            if (selectedMatchup is not null)
+            {
+                await LoadSamples(selectedOverview, selectedMatchup);
+            }
+            else
+            {
+                samplesLoading = false;
+            }
+        }
+    }
+
+    private BuildDetailsRaceRosterMatchupRequest CreateMatchupRequest(BuildDetailsRaceRosterOverviewRow row)
+    {
+        return new()
+        {
+            RatingType = Request.RatingType,
+            TimePeriod = Request.TimePeriod,
+            Commander = Request.Commander,
+            FromRating = Request.FromRating,
+            ToRating = Request.ToRating,
+            WithLeavers = Request.WithLeavers,
+            GasFilter = Request.GasFilter,
+            TeFilter = Request.TeFilter,
+            Player = Request.Player,
+            Race1 = row.Race1,
+            Race2 = row.Race2,
+            Race3 = row.Race3,
+        };
+    }
+
+    private BuildDetailsRaceRosterSamplesRequest CreateSamplesRequest(BuildDetailsRaceRosterOverviewRow overview, BuildDetailsRaceRosterMatchupRow matchup)
+    {
+        return new()
+        {
+            RatingType = Request.RatingType,
+            TimePeriod = Request.TimePeriod,
+            Commander = Request.Commander,
+            FromRating = Request.FromRating,
+            ToRating = Request.ToRating,
+            WithLeavers = Request.WithLeavers,
+            GasFilter = Request.GasFilter,
+            TeFilter = Request.TeFilter,
+            Player = Request.Player,
+            Race1 = overview.Race1,
+            Race2 = overview.Race2,
+            Race3 = overview.Race3,
+            OpponentRace1 = matchup.OpponentRace1,
+            OpponentRace2 = matchup.OpponentRace2,
+            OpponentRace3 = matchup.OpponentRace3,
+            Count = 10,
+        };
+    }
+
+    private void SortOverview(string column)
+    {
+        ToggleSort(overviewOrders, column);
+    }
+
+    private void SortMatchups(string column)
+    {
+        ToggleSort(matchupOrders, column);
+    }
+
+    private static void ToggleSort(List<TableOrder> orders, string column)
+    {
+        var order = orders[0];
+        if (order.Column == column)
+        {
+            order.Ascending = !order.Ascending;
+        }
+        else
+        {
+            order.Column = column;
+            order.Ascending = column is nameof(BuildDetailsRaceRosterOverviewRow.Race1)
+                or nameof(BuildDetailsRaceRosterMatchupRow.OpponentRace1);
+        }
+    }
+
+    private IEnumerable<BuildDetailsRaceRosterOverviewRow> ApplyOverviewDirection(IOrderedEnumerable<BuildDetailsRaceRosterOverviewRow> rows)
+    {
+        return overviewOrders[0].Ascending ? rows : rows.Reverse();
+    }
+
+    private IEnumerable<BuildDetailsRaceRosterMatchupRow> ApplyMatchupDirection(IOrderedEnumerable<BuildDetailsRaceRosterMatchupRow> rows)
+    {
+        return matchupOrders[0].Ascending ? rows : rows.Reverse();
+    }
+
+    private bool IsSelectedOverview(BuildDetailsRaceRosterOverviewRow row)
+    {
+        return selectedOverview is not null
+            && row.Race1 == selectedOverview.Race1
+            && row.Race2 == selectedOverview.Race2
+            && row.Race3 == selectedOverview.Race3;
+    }
+
+    private bool IsSelectedMatchup(BuildDetailsRaceRosterMatchupRow row)
+    {
+        return selectedMatchup is not null
+            && row.OpponentRace1 == selectedMatchup.OpponentRace1
+            && row.OpponentRace2 == selectedMatchup.OpponentRace2
+            && row.OpponentRace3 == selectedMatchup.OpponentRace3;
+    }
+
+    private bool IsOverviewVisible(BuildDetailsRaceRosterOverviewRow row)
+    {
+        return showOverviewAnecdotalResults || row.Games >= AnecdotalGameThreshold;
+    }
+
+    private bool IsMatchupVisible(BuildDetailsRaceRosterMatchupRow row)
+    {
+        return showMatchupAnecdotalResults || row.Games >= AnecdotalGameThreshold;
+    }
+
+    private async Task LoadReplayDetails(string replayHash)
+    {
+        replayDetails = await ReplayRepository.GetReplayDetails(replayHash);
+        if (replayDetails is not null)
+        {
+            replayModal?.Show(replayDetails);
+        }
+    }
+
+    private void CloseReplay()
+    {
+        replayDetails = null;
+    }
+
+    private static string GetGainClass(double gain)
+    {
+        return gain < 0 ? "text-danger" : "text-success";
+    }
+
+    private static string GetConfidenceLabel(int games)
+    {
+        return games switch
+        {
+            < 5 => "Very Low",
+            < 20 => "Low",
+            < 100 => "Medium",
+            _ => "High",
+        };
+    }
+
+    public void Dispose()
+    {
+        cts.Cancel();
+        cts.Dispose();
+    }
+}

--- a/src/common/dsstats.weblib/BuildDetails/RaceRosterIcons.razor
+++ b/src/common/dsstats.weblib/BuildDetails/RaceRosterIcons.razor
@@ -1,0 +1,19 @@
+@using dsstats.shared
+
+<span class="d-inline-flex align-items-center gap-1" title="@BuildDetailsRequestExtensions.GetRosterName(Race1, Race2, Race3)">
+    <span class="preload-@(Race1.ToString().ToLowerInvariant())" style="width: 24px; height: 24px;"></span>
+    <span class="preload-@(Race2.ToString().ToLowerInvariant())" style="width: 24px; height: 24px;"></span>
+    <span class="preload-@(Race3.ToString().ToLowerInvariant())" style="width: 24px; height: 24px;"></span>
+    <span class="visually-hidden">@BuildDetailsRequestExtensions.GetRosterName(Race1, Race2, Race3)</span>
+</span>
+
+@code {
+    [Parameter, EditorRequired]
+    public Commander Race1 { get; set; }
+
+    [Parameter, EditorRequired]
+    public Commander Race2 { get; set; }
+
+    [Parameter, EditorRequired]
+    public Commander Race3 { get; set; }
+}

--- a/src/server/dsstats.api/Controllers/BuildDetailsController.cs
+++ b/src/server/dsstats.api/Controllers/BuildDetailsController.cs
@@ -52,4 +52,31 @@ public sealed class BuildDetailsController(IBuildDetailsService buildDetailsServ
         var rows = await buildDetailsService.GetTeamBuildSampleReplays(request, token);
         return Ok(rows);
     }
+
+    [HttpPost("race-rosters/overview")]
+    public async Task<ActionResult<List<BuildDetailsRaceRosterOverviewRow>>> GetRaceRosterOverview(
+        [FromBody] BuildDetailsRequest request,
+        CancellationToken token = default)
+    {
+        var rows = await buildDetailsService.GetRaceRosterOverview(request, token);
+        return Ok(rows);
+    }
+
+    [HttpPost("race-rosters/matchups")]
+    public async Task<ActionResult<List<BuildDetailsRaceRosterMatchupRow>>> GetRaceRosterMatchups(
+        [FromBody] BuildDetailsRaceRosterMatchupRequest request,
+        CancellationToken token = default)
+    {
+        var rows = await buildDetailsService.GetRaceRosterMatchups(request, token);
+        return Ok(rows);
+    }
+
+    [HttpPost("race-rosters/samples")]
+    public async Task<ActionResult<List<BuildDetailsRaceRosterSampleReplay>>> GetRaceRosterSampleReplays(
+        [FromBody] BuildDetailsRaceRosterSamplesRequest request,
+        CancellationToken token = default)
+    {
+        var rows = await buildDetailsService.GetRaceRosterSampleReplays(request, token);
+        return Ok(rows);
+    }
 }

--- a/src/server/dsstats.apiServices/BuildDetailsService.cs
+++ b/src/server/dsstats.apiServices/BuildDetailsService.cs
@@ -77,4 +77,46 @@ public sealed class BuildDetailsService(IHttpClientFactory httpClientFactory) : 
             return [];
         }
     }
+
+    public async Task<List<BuildDetailsRaceRosterOverviewRow>> GetRaceRosterOverview(BuildDetailsRequest request, CancellationToken token = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync("api10/BuildDetails/race-rosters/overview", request, token);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<List<BuildDetailsRaceRosterOverviewRow>>(cancellationToken: token) ?? [];
+        }
+        catch (Exception)
+        {
+            return [];
+        }
+    }
+
+    public async Task<List<BuildDetailsRaceRosterMatchupRow>> GetRaceRosterMatchups(BuildDetailsRaceRosterMatchupRequest request, CancellationToken token = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync("api10/BuildDetails/race-rosters/matchups", request, token);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<List<BuildDetailsRaceRosterMatchupRow>>(cancellationToken: token) ?? [];
+        }
+        catch (Exception)
+        {
+            return [];
+        }
+    }
+
+    public async Task<List<BuildDetailsRaceRosterSampleReplay>> GetRaceRosterSampleReplays(BuildDetailsRaceRosterSamplesRequest request, CancellationToken token = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync("api10/BuildDetails/race-rosters/samples", request, token);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<List<BuildDetailsRaceRosterSampleReplay>>(cancellationToken: token) ?? [];
+        }
+        catch (Exception)
+        {
+            return [];
+        }
+    }
 }

--- a/src/server/dsstats.dbServices/BuildDetails/BuildDetailsService.cs
+++ b/src/server/dsstats.dbServices/BuildDetails/BuildDetailsService.cs
@@ -284,6 +284,204 @@ public sealed class BuildDetailsService(IDbContextFactory<DsstatsContext> contex
         }
     }
 
+    public async Task<List<BuildDetailsRaceRosterOverviewRow>> GetRaceRosterOverview(BuildDetailsRequest request, CancellationToken token = default)
+    {
+        if (!IsAllowedRaceRosterCommander(request.Commander))
+        {
+            return [];
+        }
+
+        try
+        {
+            return await memoryCache.GetOrCreateAsync($"race_roster_overview_{request.GetMemKey()}", async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+                await using var context = await contextFactory.CreateDbContextAsync(token);
+                var query = CreateRaceRosterBaseQuery(context, request);
+
+                var rows = await query
+                    .GroupBy(x => new { x.Race1, x.Race2, x.Race3 })
+                    .Select(g => new
+                    {
+                        g.Key.Race1,
+                        g.Key.Race2,
+                        g.Key.Race3,
+                        Games = g.Count(),
+                        Wins = g.Count(x => x.Won),
+                        AverageRatingGain = g.Average(x => x.TeamRatingDelta),
+                        AverageRating = g.Average(x => x.TeamRatingBefore),
+                    })
+                    .ToListAsync(token);
+
+                return rows
+                    .Select(x => new BuildDetailsRaceRosterOverviewRow
+                    {
+                        Race1 = x.Race1,
+                        Race2 = x.Race2,
+                        Race3 = x.Race3,
+                        Games = x.Games,
+                        Wins = x.Wins,
+                        AverageRatingGain = Math.Round(x.AverageRatingGain, 2),
+                        Winrate = Math.Round(100.0 * x.Wins / x.Games, 2),
+                        AverageRating = Math.Round(x.AverageRating, 0),
+                    })
+                    .OrderByDescending(x => x.AverageRatingGain)
+                    .ThenByDescending(x => x.Games)
+                    .ToList();
+            }) ?? [];
+        }
+        catch (OperationCanceledException)
+        {
+            return [];
+        }
+    }
+
+    public async Task<List<BuildDetailsRaceRosterMatchupRow>> GetRaceRosterMatchups(BuildDetailsRaceRosterMatchupRequest request, CancellationToken token = default)
+    {
+        if (!IsAllowedRaceRosterCommander(request.Commander)
+            || !IsStandardRace(request.Race1)
+            || !IsStandardRace(request.Race2)
+            || !IsStandardRace(request.Race3))
+        {
+            return [];
+        }
+
+        try
+        {
+            return await memoryCache.GetOrCreateAsync($"race_roster_matchups_{request.GetMemKey()}", async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+                await using var context = await contextFactory.CreateDbContextAsync(token);
+                var query = CreateRaceRosterBaseQuery(context, request)
+                    .Where(x => x.Race1 == request.Race1
+                        && x.Race2 == request.Race2
+                        && x.Race3 == request.Race3);
+
+                var rows = await query
+                    .GroupBy(x => new { x.Race1, x.Race2, x.Race3, x.OpponentRace1, x.OpponentRace2, x.OpponentRace3 })
+                    .Select(g => new
+                    {
+                        g.Key.Race1,
+                        g.Key.Race2,
+                        g.Key.Race3,
+                        g.Key.OpponentRace1,
+                        g.Key.OpponentRace2,
+                        g.Key.OpponentRace3,
+                        Games = g.Count(),
+                        Wins = g.Count(x => x.Won),
+                        AverageRatingGain = g.Average(x => x.TeamRatingDelta),
+                        AverageRating = g.Average(x => x.TeamRatingBefore),
+                    })
+                    .ToListAsync(token);
+
+                return rows
+                    .Select(x => new BuildDetailsRaceRosterMatchupRow
+                    {
+                        Race1 = x.Race1,
+                        Race2 = x.Race2,
+                        Race3 = x.Race3,
+                        OpponentRace1 = x.OpponentRace1,
+                        OpponentRace2 = x.OpponentRace2,
+                        OpponentRace3 = x.OpponentRace3,
+                        Games = x.Games,
+                        Wins = x.Wins,
+                        AverageRatingGain = Math.Round(x.AverageRatingGain, 2),
+                        Winrate = Math.Round(100.0 * x.Wins / x.Games, 2),
+                        AverageRating = Math.Round(x.AverageRating, 0),
+                    })
+                    .OrderByDescending(x => x.AverageRatingGain)
+                    .ThenByDescending(x => x.Games)
+                    .ToList();
+            }) ?? [];
+        }
+        catch (OperationCanceledException)
+        {
+            return [];
+        }
+    }
+
+    public async Task<List<BuildDetailsRaceRosterSampleReplay>> GetRaceRosterSampleReplays(BuildDetailsRaceRosterSamplesRequest request, CancellationToken token = default)
+    {
+        if (!IsAllowedRaceRosterCommander(request.Commander)
+            || !IsStandardRace(request.Race1)
+            || !IsStandardRace(request.Race2)
+            || !IsStandardRace(request.Race3)
+            || !IsStandardRace(request.OpponentRace1)
+            || !IsStandardRace(request.OpponentRace2)
+            || !IsStandardRace(request.OpponentRace3))
+        {
+            return [];
+        }
+
+        try
+        {
+            var take = Math.Clamp(request.Count, 1, 25);
+            await using var context = await contextFactory.CreateDbContextAsync(token);
+            var query = CreateRaceRosterBaseQuery(context, request)
+                .Where(x => x.Race1 == request.Race1
+                    && x.Race2 == request.Race2
+                    && x.Race3 == request.Race3
+                    && x.OpponentRace1 == request.OpponentRace1
+                    && x.OpponentRace2 == request.OpponentRace2
+                    && x.OpponentRace3 == request.OpponentRace3);
+
+            var rows = await query
+                .OrderByDescending(x => x.Gametime)
+                .Select(x => new RaceRosterSampleReplayProjection
+                {
+                    ReplayId = x.ReplayId,
+                    ReplayHash = x.ReplayHash,
+                    Gametime = x.Gametime,
+                    GameMode = x.GameMode,
+                    Duration = x.Duration,
+                    WinnerTeam = x.WinnerTeam,
+                    TeamId = x.TeamId,
+                    FirstGamePos = x.FirstGamePos,
+                    Race1 = x.Race1,
+                    Race2 = x.Race2,
+                    Race3 = x.Race3,
+                    OpponentRace1 = x.OpponentRace1,
+                    OpponentRace2 = x.OpponentRace2,
+                    OpponentRace3 = x.OpponentRace3,
+                    TeamRatingDelta = x.TeamRatingDelta,
+                    Exp2Win = x.ExpectedWinProbability,
+                    AvgRating = x.AvgRating,
+                    LeaverType = x.LeaverType,
+                })
+                .Take(take * 2)
+                .ToListAsync(token);
+
+            rows = rows
+                .DistinctBy(x => x.ReplayHash)
+                .Take(take)
+                .ToList();
+
+            var replayIds = rows.Select(x => x.ReplayId).ToList();
+            var players = await context.ReplayPlayers.AsNoTracking()
+                .Where(x => replayIds.Contains(x.ReplayId))
+                .OrderBy(x => x.GamePos)
+                .Select(x => new SampleReplayPlayerProjection
+                {
+                    ReplayId = x.ReplayId,
+                    Race = x.Race,
+                    Team = x.TeamId,
+                })
+                .ToListAsync(token);
+
+            var playersByReplayId = players
+                .GroupBy(x => x.ReplayId)
+                .ToDictionary(x => x.Key, x => x.ToList());
+
+            return rows
+                .Select(x => x.ToDto(playersByReplayId.GetValueOrDefault(x.ReplayId) ?? []))
+                .ToList();
+        }
+        catch (OperationCanceledException)
+        {
+            return [];
+        }
+    }
+
     private static IQueryable<BuildDetailsQueryRow> CreateBaseQuery(DsstatsContext context, BuildDetailsRequest request)
     {
         var timeInfo = Data.GetTimePeriodInfo(request.TimePeriod) ?? Data.GetTimePeriodInfo(TimePeriod.Last90Days);
@@ -432,6 +630,121 @@ public sealed class BuildDetailsService(IDbContextFactory<DsstatsContext> contex
                     };
 
         return query;
+    }
+
+    private static IQueryable<RaceRosterQueryRow> CreateRaceRosterBaseQuery(DsstatsContext context, BuildDetailsRequest request)
+    {
+        return CreateRaceRosterTeamQuery(context, request, 1, 1, 2, 3, 4, 5, 6)
+            .Concat(CreateRaceRosterTeamQuery(context, request, 2, 4, 5, 6, 1, 2, 3));
+    }
+
+    private static IQueryable<RaceRosterQueryRow> CreateRaceRosterTeamQuery(
+        DsstatsContext context,
+        BuildDetailsRequest request,
+        int teamId,
+        int pos1,
+        int pos2,
+        int pos3,
+        int oppPos1,
+        int oppPos2,
+        int oppPos3)
+    {
+        var timeInfo = Data.GetTimePeriodInfo(request.TimePeriod) ?? Data.GetTimePeriodInfo(TimePeriod.Last90Days);
+        var noMinRating = request.FromRating <= Data.MinBuildRating;
+        var noMaxRating = request.ToRating >= Data.MaxBuildRating;
+        var anyCommander = request.Commander == Commander.None;
+        var playerId = request.Player?.PlayerId ?? 0;
+        var noPlayer = playerId <= 0;
+
+        return from replay in context.Replays.AsNoTracking()
+               join replayRating in context.ReplayRatings.AsNoTracking()
+                   on replay.ReplayId equals replayRating.ReplayId
+               join p1 in context.ReplayPlayers.AsNoTracking()
+                   on new { replay.ReplayId, GamePos = pos1 } equals new { p1.ReplayId, p1.GamePos }
+               join p2 in context.ReplayPlayers.AsNoTracking()
+                   on new { replay.ReplayId, GamePos = pos2 } equals new { p2.ReplayId, p2.GamePos }
+               join p3 in context.ReplayPlayers.AsNoTracking()
+                   on new { replay.ReplayId, GamePos = pos3 } equals new { p3.ReplayId, p3.GamePos }
+               join o1 in context.ReplayPlayers.AsNoTracking()
+                   on new { replay.ReplayId, GamePos = oppPos1 } equals new { o1.ReplayId, o1.GamePos }
+               join o2 in context.ReplayPlayers.AsNoTracking()
+                   on new { replay.ReplayId, GamePos = oppPos2 } equals new { o2.ReplayId, o2.GamePos }
+               join o3 in context.ReplayPlayers.AsNoTracking()
+                   on new { replay.ReplayId, GamePos = oppPos3 } equals new { o3.ReplayId, o3.GamePos }
+               join r1 in context.ReplayPlayerRatings.AsNoTracking()
+                   on new { replayRating.ReplayRatingId, p1.ReplayPlayerId } equals new { r1.ReplayRatingId, r1.ReplayPlayerId }
+               join r2 in context.ReplayPlayerRatings.AsNoTracking()
+                   on new { replayRating.ReplayRatingId, p2.ReplayPlayerId } equals new { r2.ReplayRatingId, r2.ReplayPlayerId }
+               join r3 in context.ReplayPlayerRatings.AsNoTracking()
+                   on new { replayRating.ReplayRatingId, p3.ReplayPlayerId } equals new { r3.ReplayRatingId, r3.ReplayPlayerId }
+               where replay.GameMode == GameMode.Standard
+                   && replay.PlayerCount == 6
+                   && replay.WinnerTeam > 0
+                   && p1.TeamId == teamId
+                   && p2.TeamId == teamId
+                   && p3.TeamId == teamId
+                   && o1.TeamId != teamId
+                   && o2.TeamId != teamId
+                   && o3.TeamId != teamId
+                   && (p1.Race == Commander.Protoss || p1.Race == Commander.Terran || p1.Race == Commander.Zerg)
+                   && (p2.Race == Commander.Protoss || p2.Race == Commander.Terran || p2.Race == Commander.Zerg)
+                   && (p3.Race == Commander.Protoss || p3.Race == Commander.Terran || p3.Race == Commander.Zerg)
+                   && (o1.Race == Commander.Protoss || o1.Race == Commander.Terran || o1.Race == Commander.Zerg)
+                   && (o2.Race == Commander.Protoss || o2.Race == Commander.Terran || o2.Race == Commander.Zerg)
+                   && (o3.Race == Commander.Protoss || o3.Race == Commander.Terran || o3.Race == Commander.Zerg)
+                   && (request.TeFilter == BuildDetailsTeFilter.All
+                       || (request.TeFilter == BuildDetailsTeFilter.TE && replay.TE)
+                       || (request.TeFilter == BuildDetailsTeFilter.NonTE && !replay.TE))
+                   && replay.Gametime >= timeInfo.Start
+                   && (!timeInfo.HasEnd || replay.Gametime < timeInfo.End)
+                   && ((replay.TE
+                           && replayRating.RatingType == RatingType.StandardTE
+                           && r1.RatingType == RatingType.StandardTE
+                           && r2.RatingType == RatingType.StandardTE
+                           && r3.RatingType == RatingType.StandardTE)
+                       || (!replay.TE
+                           && replayRating.RatingType == RatingType.Standard
+                           && r1.RatingType == RatingType.Standard
+                           && r2.RatingType == RatingType.Standard
+                           && r3.RatingType == RatingType.Standard))
+                   && (request.WithLeavers || replayRating.LeaverType == LeaverType.None)
+                   && (noMinRating || ((r1.RatingBefore + r2.RatingBefore + r3.RatingBefore) / 3.0) >= request.FromRating)
+                   && (noMaxRating || ((r1.RatingBefore + r2.RatingBefore + r3.RatingBefore) / 3.0) <= request.ToRating)
+                   && (anyCommander || p1.Race == request.Commander || p2.Race == request.Commander || p3.Race == request.Commander)
+                   && (noPlayer || r1.PlayerId == playerId || r2.PlayerId == playerId || r3.PlayerId == playerId)
+               select new RaceRosterQueryRow
+               {
+                   ReplayId = replay.ReplayId,
+                   ReplayHash = replay.ReplayHash,
+                   Gametime = replay.Gametime,
+                   GameMode = replay.GameMode,
+                   Duration = replay.Duration,
+                   WinnerTeam = replay.WinnerTeam,
+                   TeamId = teamId,
+                   FirstGamePos = pos1,
+                   Race1 = p1.Race,
+                   Race2 = p2.Race,
+                   Race3 = p3.Race,
+                   OpponentRace1 = o1.Race,
+                   OpponentRace2 = o2.Race,
+                   OpponentRace3 = o3.Race,
+                   Won = replay.WinnerTeam == teamId,
+                   TeamRatingBefore = (r1.RatingBefore + r2.RatingBefore + r3.RatingBefore) / 3.0,
+                   TeamRatingDelta = (r1.RatingDelta + r2.RatingDelta + r3.RatingDelta) / 3.0,
+                   ExpectedWinProbability = replayRating.ExpectedWinProbability,
+                   AvgRating = replayRating.AvgRating,
+                   LeaverType = replayRating.LeaverType,
+               };
+    }
+
+    private static bool IsAllowedRaceRosterCommander(Commander commander)
+    {
+        return commander == Commander.None || IsStandardRace(commander);
+    }
+
+    private static bool IsStandardRace(Commander commander)
+    {
+        return commander is Commander.Protoss or Commander.Terran or Commander.Zerg;
     }
 
     private sealed class BuildDetailsQueryRow
@@ -596,6 +909,80 @@ public sealed class BuildDetailsService(IDbContextFactory<DsstatsContext> contex
                     AvgRating = AvgRating,
                     LeaverType = LeaverType,
                     PlayerPos = LeaderGamePos,
+                    PlayerGain = TeamRatingDelta,
+                }
+            };
+        }
+    }
+
+    private sealed class RaceRosterQueryRow
+    {
+        public int ReplayId { get; init; }
+        public string ReplayHash { get; init; } = string.Empty;
+        public DateTime Gametime { get; init; }
+        public GameMode GameMode { get; init; }
+        public int Duration { get; init; }
+        public int WinnerTeam { get; init; }
+        public int TeamId { get; init; }
+        public int FirstGamePos { get; init; }
+        public Commander Race1 { get; init; }
+        public Commander Race2 { get; init; }
+        public Commander Race3 { get; init; }
+        public Commander OpponentRace1 { get; init; }
+        public Commander OpponentRace2 { get; init; }
+        public Commander OpponentRace3 { get; init; }
+        public bool Won { get; init; }
+        public double TeamRatingBefore { get; init; }
+        public double TeamRatingDelta { get; init; }
+        public double ExpectedWinProbability { get; init; }
+        public int AvgRating { get; init; }
+        public LeaverType LeaverType { get; init; }
+    }
+
+    private sealed class RaceRosterSampleReplayProjection
+    {
+        public int ReplayId { get; init; }
+        public string ReplayHash { get; init; } = string.Empty;
+        public DateTime Gametime { get; init; }
+        public GameMode GameMode { get; init; }
+        public int Duration { get; init; }
+        public int WinnerTeam { get; init; }
+        public int TeamId { get; init; }
+        public int FirstGamePos { get; init; }
+        public Commander Race1 { get; init; }
+        public Commander Race2 { get; init; }
+        public Commander Race3 { get; init; }
+        public Commander OpponentRace1 { get; init; }
+        public Commander OpponentRace2 { get; init; }
+        public Commander OpponentRace3 { get; init; }
+        public double TeamRatingDelta { get; init; }
+        public double Exp2Win { get; init; }
+        public int AvgRating { get; init; }
+        public LeaverType LeaverType { get; init; }
+
+        public BuildDetailsRaceRosterSampleReplay ToDto(List<SampleReplayPlayerProjection> players)
+        {
+            return new BuildDetailsRaceRosterSampleReplay
+            {
+                Race1 = Race1,
+                Race2 = Race2,
+                Race3 = Race3,
+                OpponentRace1 = OpponentRace1,
+                OpponentRace2 = OpponentRace2,
+                OpponentRace3 = OpponentRace3,
+                Replay = new ReplayListDto
+                {
+                    ReplayHash = ReplayHash,
+                    Gametime = Gametime,
+                    GameMode = GameMode,
+                    Duration = Duration,
+                    WinnerTeam = WinnerTeam,
+                    CommandersTeam1 = players.Where(x => x.Team == 1).Select(x => x.Race).ToList(),
+                    CommandersTeam2 = players.Where(x => x.Team == 2).Select(x => x.Race).ToList(),
+                    Exp2Win = Exp2Win,
+                    AvgRating = AvgRating,
+                    LeaverType = LeaverType,
+                    PlayerPos = FirstGamePos,
                     PlayerGain = TeamRatingDelta,
                 }
             };

--- a/src/server/dsstats.web/Components/Pages/BuildDetailsPage.razor
+++ b/src/server/dsstats.web/Components/Pages/BuildDetailsPage.razor
@@ -7,7 +7,7 @@
 
 <PageTitle>dsstats - build details</PageTitle>
 
-<dsstats.weblib.BuildDetails.BuildDetailsComponent Request="Request" OnRequestChanged="RequestChanged" />
+<dsstats.weblib.BuildDetails.BuildDetailsComponent Request="Request" ActiveTab="CurrentTab" OnRequestChanged="RequestChanged" OnActiveTabChanged="TabChanged" />
 
 @code {
     [SupplyParameterFromQuery]
@@ -34,8 +34,12 @@
     [SupplyParameterFromQuery]
     public string? Player { get; set; }
 
+    [SupplyParameterFromQuery]
+    public string? Tab { get; set; }
+
     private const int RatingStep = 50;
     private BuildDetailsRequest Request = new();
+    private BuildDetailsTab CurrentTab = BuildDetailsTab.BuildDetails;
 
     private static readonly FrozenDictionary<string, string> paramMap = new Dictionary<string, string>
     {
@@ -63,6 +67,7 @@
             TeFilter = EnumExtensions.ParseEnumOrDefault(Te, BuildDetailsTeFilter.All),
             Player = DecodePlayer(Player),
         };
+        CurrentTab = EnumExtensions.ParseEnumOrDefault(Tab, BuildDetailsTab.BuildDetails);
 
         if (Request.FromRating > Request.ToRating)
         {
@@ -93,8 +98,23 @@
 
     private void RequestChanged(BuildDetailsRequest request)
     {
+        NavigateToRequest(request, CurrentTab);
+    }
+
+    private void TabChanged(BuildDetailsTab tab)
+    {
+        CurrentTab = tab;
+        NavigateToRequest(Request, CurrentTab);
+    }
+
+    private void NavigateToRequest(BuildDetailsRequest request, BuildDetailsTab tab)
+    {
+        var query = new Dictionary<string, object?>(request.BuildQueryParams(paramMap))
+        {
+            ["Tab"] = tab.ToString(),
+        };
+
         NavigationManager.NavigateTo(
-            NavigationManager.GetUriWithQueryParameters(
-                new Dictionary<string, object?>(request.BuildQueryParams(paramMap))));
+            NavigationManager.GetUriWithQueryParameters(query));
     }
 }

--- a/src/tests/dsstats.tests/BuildDetailsService.Tests.cs
+++ b/src/tests/dsstats.tests/BuildDetailsService.Tests.cs
@@ -312,6 +312,120 @@ public sealed class BuildDetailsServiceTests
         Assert.IsTrue(rows[0].Replay.CommandersTeam1.Contains(Commander.Terran));
     }
 
+    [TestMethod]
+    public async Task GetRaceRosterOverview_AggregatesOrderedRosterAverageGainAndWinrate()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await fixture.SeedRaceRosterReplayAsync(1, winnerTeam: 1, team1Deltas: [9, 6, 3], team2Deltas: [-3, -6, -9]);
+        await fixture.SeedRaceRosterReplayAsync(2, winnerTeam: 2, team1Deltas: [-3, -6, -9], team2Deltas: [3, 6, 9]);
+
+        var rows = await fixture.Service.GetRaceRosterOverview(CreateRaceRosterRequest());
+        var row = rows.Single(x => x.Race1 == Commander.Protoss && x.Race2 == Commander.Terran && x.Race3 == Commander.Zerg);
+
+        Assert.AreEqual(2, row.Games);
+        Assert.AreEqual(1, row.Wins);
+        Assert.AreEqual(0.0, row.AverageRatingGain, 0.001);
+        Assert.AreEqual(50.0, row.Winrate, 0.001);
+    }
+
+    [TestMethod]
+    public async Task GetRaceRosterOverview_KeepsRosterOrderDistinct()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await fixture.SeedRaceRosterReplayAsync(1, team1Races: [Commander.Protoss, Commander.Terran, Commander.Zerg]);
+        await fixture.SeedRaceRosterReplayAsync(2, team1Races: [Commander.Terran, Commander.Protoss, Commander.Zerg]);
+
+        var rows = await fixture.Service.GetRaceRosterOverview(CreateRaceRosterRequest());
+
+        Assert.IsTrue(rows.Any(x => x.Race1 == Commander.Protoss && x.Race2 == Commander.Terran && x.Race3 == Commander.Zerg));
+        Assert.IsTrue(rows.Any(x => x.Race1 == Commander.Terran && x.Race2 == Commander.Protoss && x.Race3 == Commander.Zerg));
+    }
+
+    [TestMethod]
+    public async Task GetRaceRosterMatchups_AggregatesSelectedRosterVersusOpponentRoster()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await fixture.SeedRaceRosterReplayAsync(1, winnerTeam: 1, team1Deltas: [9, 6, 3], team2Races: [Commander.Terran, Commander.Terran, Commander.Terran]);
+        await fixture.SeedRaceRosterReplayAsync(2, winnerTeam: 2, team1Deltas: [-3, -6, -9], team2Races: [Commander.Terran, Commander.Terran, Commander.Terran]);
+        await fixture.SeedRaceRosterReplayAsync(3, winnerTeam: 1, team2Races: [Commander.Zerg, Commander.Zerg, Commander.Zerg]);
+
+        var rows = await fixture.Service.GetRaceRosterMatchups(new BuildDetailsRaceRosterMatchupRequest
+        {
+            RatingType = RatingType.All,
+            TimePeriod = TimePeriod.AllTime,
+            Commander = Commander.None,
+            FromRating = Data.MinBuildRating,
+            ToRating = Data.MaxBuildRating,
+            Race1 = Commander.Protoss,
+            Race2 = Commander.Terran,
+            Race3 = Commander.Zerg,
+        });
+        var row = rows.Single(x => x.OpponentRace1 == Commander.Terran && x.OpponentRace2 == Commander.Terran && x.OpponentRace3 == Commander.Terran);
+
+        Assert.AreEqual(2, row.Games);
+        Assert.AreEqual(1, row.Wins);
+        Assert.AreEqual(0.0, row.AverageRatingGain, 0.001);
+        Assert.AreEqual(50.0, row.Winrate, 0.001);
+    }
+
+    [TestMethod]
+    public async Task GetRaceRosterOverview_FiltersCommanderPlayerTeLeaversRatingAndStandardOnly()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await fixture.SeedRaceRosterReplayAsync(1, te: true, team1PlayerIds: [42, 11, 12], team1Ratings: [1800, 1800, 1800]);
+        await fixture.SeedRaceRosterReplayAsync(2, te: false, team1PlayerIds: [42, 21, 22], team1Ratings: [1800, 1800, 1800]);
+        await fixture.SeedRaceRosterReplayAsync(3, leaverType: LeaverType.OneLeaver, team1PlayerIds: [42, 31, 32], team1Ratings: [1800, 1800, 1800]);
+        await fixture.SeedRaceRosterReplayAsync(4, team1PlayerIds: [99, 41, 42], team1Ratings: [1300, 1300, 1300]);
+        await fixture.SeedRaceRosterReplayAsync(5, gameMode: GameMode.Commanders);
+        await fixture.SeedRaceRosterReplayAsync(6, playerCount: 4);
+        await fixture.SeedRaceRosterReplayAsync(7, winnerTeam: 0);
+        await fixture.SeedRaceRosterReplayAsync(8, team1Races: [Commander.Protoss, Commander.Abathur, Commander.Zerg]);
+
+        var request = CreateRaceRosterRequest(BuildDetailsTeFilter.TE);
+        request.Commander = Commander.Terran;
+        request.Player = CreatePlayer(42);
+        request.FromRating = 1500;
+        var rows = await fixture.Service.GetRaceRosterOverview(request);
+
+        Assert.AreEqual(1, rows.Single(x => x.Race1 == Commander.Protoss && x.Race2 == Commander.Terran && x.Race3 == Commander.Zerg).Games);
+
+        request.Commander = Commander.Abathur;
+        var nonStandardRows = await fixture.Service.GetRaceRosterOverview(request);
+        Assert.AreEqual(0, nonStandardRows.Count);
+    }
+
+    [TestMethod]
+    public async Task GetRaceRosterSampleReplays_ReturnsNewestDistinctReplayMetadata()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await fixture.SeedRaceRosterReplayAsync(1);
+        await fixture.SeedRaceRosterReplayAsync(2);
+        await fixture.SeedRaceRosterReplayAsync(3);
+
+        var rows = await fixture.Service.GetRaceRosterSampleReplays(new BuildDetailsRaceRosterSamplesRequest
+        {
+            RatingType = RatingType.All,
+            TimePeriod = TimePeriod.AllTime,
+            Commander = Commander.None,
+            FromRating = Data.MinBuildRating,
+            ToRating = Data.MaxBuildRating,
+            Race1 = Commander.Protoss,
+            Race2 = Commander.Terran,
+            Race3 = Commander.Zerg,
+            OpponentRace1 = Commander.Terran,
+            OpponentRace2 = Commander.Terran,
+            OpponentRace3 = Commander.Terran,
+            Count = 2,
+        });
+
+        Assert.AreEqual(2, rows.Count);
+        Assert.AreEqual("race-hash-3", rows[0].Replay.ReplayHash);
+        Assert.AreEqual("race-hash-2", rows[1].Replay.ReplayHash);
+        Assert.AreEqual(1, rows[0].Replay.PlayerPos);
+        CollectionAssert.AreEqual(new[] { Commander.Protoss, Commander.Terran, Commander.Zerg }, rows[0].Replay.CommandersTeam1);
+        CollectionAssert.AreEqual(new[] { Commander.Terran, Commander.Terran, Commander.Terran }, rows[0].Replay.CommandersTeam2);
+    }
+
     private static BuildDetailsRequest CreateRequest(BuildDetailsTeFilter teFilter = BuildDetailsTeFilter.All)
     {
         return new()
@@ -319,6 +433,19 @@ public sealed class BuildDetailsServiceTests
             RatingType = RatingType.All,
             TimePeriod = TimePeriod.AllTime,
             Commander = Commander.Protoss,
+            FromRating = Data.MinBuildRating,
+            ToRating = Data.MaxBuildRating,
+            TeFilter = teFilter,
+        };
+    }
+
+    private static BuildDetailsRequest CreateRaceRosterRequest(BuildDetailsTeFilter teFilter = BuildDetailsTeFilter.All)
+    {
+        return new()
+        {
+            RatingType = RatingType.All,
+            TimePeriod = TimePeriod.AllTime,
+            Commander = Commander.None,
             FromRating = Data.MinBuildRating,
             ToRating = Data.MaxBuildRating,
             TeFilter = teFilter,
@@ -692,6 +819,133 @@ public sealed class BuildDetailsServiceTests
                         FollowerReplayPlayerId = followerReplayPlayerId
                     }
                 ]
+            });
+
+            await Context.SaveChangesAsync();
+        }
+
+        public async Task SeedRaceRosterReplayAsync(
+            int replayId,
+            Commander[]? team1Races = null,
+            Commander[]? team2Races = null,
+            int winnerTeam = 1,
+            double[]? team1Deltas = null,
+            double[]? team2Deltas = null,
+            double[]? team1Ratings = null,
+            double[]? team2Ratings = null,
+            int[]? team1PlayerIds = null,
+            int[]? team2PlayerIds = null,
+            LeaverType leaverType = LeaverType.None,
+            bool te = true,
+            int playerCount = 6,
+            GameMode gameMode = GameMode.Standard)
+        {
+            team1Races ??= [Commander.Protoss, Commander.Terran, Commander.Zerg];
+            team2Races ??= [Commander.Terran, Commander.Terran, Commander.Terran];
+            team1Deltas ??= [6.0, 6.0, 6.0];
+            team2Deltas ??= [-6.0, -6.0, -6.0];
+            team1Ratings ??= [1800.0, 1800.0, 1800.0];
+            team2Ratings ??= [1800.0, 1800.0, 1800.0];
+            team1PlayerIds ??= [replayId * 1000 + 1, replayId * 1000 + 2, replayId * 1000 + 3];
+            team2PlayerIds ??= [replayId * 1000 + 4, replayId * 1000 + 5, replayId * 1000 + 6];
+
+            var ratingType = te ? RatingType.StandardTE : RatingType.Standard;
+            var gametime = new DateTime(2026, 3, 1).AddDays(replayId);
+            var replayRatingId = replayId * 1000 + 500;
+
+            for (var i = 0; i < 3; i++)
+            {
+                await AddPlayerIfMissing(team1PlayerIds[i], $"RaceTeam1Player{team1PlayerIds[i]}");
+                await AddPlayerIfMissing(team2PlayerIds[i], $"RaceTeam2Player{team2PlayerIds[i]}");
+            }
+
+            Context.Replays.Add(new Replay
+            {
+                ReplayId = replayId,
+                FileName = $"RaceReplay-{replayId}.SC2Replay",
+                Title = $"Race Replay {replayId}",
+                Version = "1.0",
+                GameMode = gameMode,
+                RegionId = 1,
+                TE = te,
+                PlayerCount = playerCount,
+                Gametime = gametime,
+                Duration = 900,
+                WinnerTeam = winnerTeam,
+                ReplayHash = $"race-hash-{replayId}",
+                CompatHash = $"race-compat-{replayId}",
+                Imported = gametime.AddMinutes(1),
+                Uploaded = true
+            });
+
+            for (var i = 0; i < 3; i++)
+            {
+                var team1ReplayPlayerId = replayId * 10000 + i + 1;
+                var team2ReplayPlayerId = replayId * 10000 + i + 4;
+
+                Context.ReplayPlayers.AddRange(
+                    new ReplayPlayer
+                    {
+                        ReplayPlayerId = team1ReplayPlayerId,
+                        ReplayId = replayId,
+                        PlayerId = team1PlayerIds[i],
+                        Name = $"RaceTeam1Player{replayId}-{i}",
+                        Race = team1Races[i],
+                        SelectedRace = team1Races[i],
+                        TeamId = 1,
+                        GamePos = i + 1,
+                        Duration = 900,
+                        Result = winnerTeam == 1 ? PlayerResult.Win : PlayerResult.Los
+                    },
+                    new ReplayPlayer
+                    {
+                        ReplayPlayerId = team2ReplayPlayerId,
+                        ReplayId = replayId,
+                        PlayerId = team2PlayerIds[i],
+                        Name = $"RaceTeam2Player{replayId}-{i}",
+                        Race = team2Races[i],
+                        SelectedRace = team2Races[i],
+                        TeamId = 2,
+                        GamePos = i + 4,
+                        Duration = 900,
+                        Result = winnerTeam == 2 ? PlayerResult.Win : PlayerResult.Los
+                    });
+
+                Context.ReplayPlayerRatings.AddRange(
+                    new ReplayPlayerRating
+                    {
+                        ReplayPlayerRatingId = replayId * 100000 + i + 1,
+                        RatingType = ratingType,
+                        RatingBefore = team1Ratings[i],
+                        RatingDelta = team1Deltas[i],
+                        ExpectedDelta = 0,
+                        Games = 10,
+                        ReplayRatingId = replayRatingId,
+                        ReplayPlayerId = team1ReplayPlayerId,
+                        PlayerId = team1PlayerIds[i]
+                    },
+                    new ReplayPlayerRating
+                    {
+                        ReplayPlayerRatingId = replayId * 100000 + i + 4,
+                        RatingType = ratingType,
+                        RatingBefore = team2Ratings[i],
+                        RatingDelta = team2Deltas[i],
+                        ExpectedDelta = 0,
+                        Games = 10,
+                        ReplayRatingId = replayRatingId,
+                        ReplayPlayerId = team2ReplayPlayerId,
+                        PlayerId = team2PlayerIds[i]
+                    });
+            }
+
+            Context.ReplayRatings.Add(new ReplayRating
+            {
+                ReplayRatingId = replayRatingId,
+                RatingType = ratingType,
+                LeaverType = leaverType,
+                ExpectedWinProbability = 0.5,
+                AvgRating = 1800 + replayId,
+                ReplayId = replayId
             });
 
             await Context.SaveChangesAsync();


### PR DESCRIPTION
## Summary

Adds a Race Rosters tab to Build Details for ordered standard race rosters and matchup success.

## Changes

- Adds shared race-roster DTOs, service methods, API endpoints, and API client methods.
- Implements efficient grouped EF queries for race roster overview, roster-vs-roster matchups, and bounded sample replays.
- Adds the Race Rosters UI with preload race icons, anecdotal-result filters, replay samples, and tab query parameter support.
- Adds service coverage for ordered roster aggregation, matchup stats, filters, standard-only behavior, and sample replay metadata.

## Validation

- `dotnet test src/tests/dsstats.tests/dsstats.tests.sln` passed: 224/224 tests.
- `dotnet build src/server/server.sln` passed with 0 warnings and 0 errors.