### PR TITLE
Fix MAUI spawn playback upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ We really like people helping us with the project. Nevertheless, take your time 
 <details open="open"><summary>v3.0.7</summary>
 
 >- Add Build Details feature. Thanks to TOMage for the suggestion.
+>- Fix maui player stats
+>- Add dsplay
 
 </details>
 
@@ -69,7 +71,7 @@ We really like people helping us with the project. Nevertheless, take your time 
 
 </details>
 
-<details open="open"><summary>v3.0.0</summary>
+<details><summary>v3.0.0</summary>
 
 >- Complete rewrite/upgrade to .NET 10
 >- RatingType 'All' includes all Direct Strike games (1v1, brawl, ...)

--- a/src/maui/dsstats.maui/MauiProgram.cs
+++ b/src/maui/dsstats.maui/MauiProgram.cs
@@ -55,7 +55,7 @@ namespace dsstats.maui
             );
             builder.Services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<DsstatsContext>>().CreateDbContext());
 
-            var apiUrl = "http://localhost:5279"; // "https://dsstats.pax77.org"; // "http://localhost:5279";
+            var apiUrl = "https://dsstats.pax77.org"; // "http://localhost:5279";
             builder.Services.AddHttpClient("api", httpClient =>
             {
                 httpClient.BaseAddress = new Uri(apiUrl);

--- a/src/maui/dsstats.maui/MauiProgram.cs
+++ b/src/maui/dsstats.maui/MauiProgram.cs
@@ -87,6 +87,7 @@ namespace dsstats.maui
 
             builder.Services.AddSingleton<IRatingService, RatingsService>();
             builder.Services.AddScoped<IPlayerService, apiServices.PlayerService>();
+            builder.Services.AddScoped<IStatsService, apiServices.StatsService>();
 
             builder.Services.AddScoped<IReplayRepository, ReplayRepository>();
             builder.Services.AddKeyedScoped<IReplayRepository, apiServices.ReplayRepository>("api");

--- a/src/maui/dsstats.maui/MauiProgram.cs
+++ b/src/maui/dsstats.maui/MauiProgram.cs
@@ -55,7 +55,7 @@ namespace dsstats.maui
             );
             builder.Services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<DsstatsContext>>().CreateDbContext());
 
-            var apiUrl = "https://dsstats.pax77.org"; // "http://localhost:5279";
+            var apiUrl = "http://localhost:5279"; // "https://dsstats.pax77.org"; // "http://localhost:5279";
             builder.Services.AddHttpClient("api", httpClient =>
             {
                 httpClient.BaseAddress = new Uri(apiUrl);

--- a/src/maui/dsstats.maui/NavMenu.razor
+++ b/src/maui/dsstats.maui/NavMenu.razor
@@ -26,7 +26,7 @@
 				</li>
 			</ul>
 			<span class="navbar-text">
-				v3.0.6
+				v3.0.7
 			</span>
 		</div>
 	</div>

--- a/src/maui/dsstats.maui/Platforms/Windows/Package.appxmanifest
+++ b/src/maui/dsstats.maui/Platforms/Windows/Package.appxmanifest
@@ -8,7 +8,7 @@
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   IgnorableNamespaces="uap rescap com desktop">
 
-  <Identity Name="29898PhilippHetzner.141231D0ED353" Publisher="CN=592AF738-4E2A-4BF3-87A7-D07953D08DE9" Version="3.0.6.0" />
+  <Identity Name="29898PhilippHetzner.141231D0ED353" Publisher="CN=592AF738-4E2A-4BF3-87A7-D07953D08DE9" Version="3.0.7.0" />
 
   <Properties>
     <DisplayName>$placeholder$</DisplayName>

--- a/src/maui/dsstats.maui/Services/DsstatsService.Pipeline.cs
+++ b/src/maui/dsstats.maui/Services/DsstatsService.Pipeline.cs
@@ -4,6 +4,7 @@ using dsstats.dbServices;
 using dsstats.maui.Services.Models;
 using dsstats.parser;
 using dsstats.shared;
+using System.IO.Compression;
 using System.Threading.Channels;
 
 namespace dsstats.maui.Services;
@@ -63,7 +64,7 @@ public sealed partial class DsstatsService
     {
         using var progressCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        var channel = Channel.CreateBounded<ReplayDto>(
+        var channel = Channel.CreateBounded<ReplayImportDto>(
             new BoundedChannelOptions(DecodeBacklogCapacity)
             {
                 SingleWriter = false,
@@ -128,7 +129,7 @@ public sealed partial class DsstatsService
     private async Task DecodeToChannelAsync(
         MauiConfig config,
         List<string> replayPaths,
-        ChannelWriter<ReplayDto> writer,
+        ChannelWriter<ReplayImportDto> writer,
         CancellationToken ct)
     {
         try
@@ -144,14 +145,14 @@ public sealed partial class DsstatsService
                 async (replayPath, token) =>
                 {
                     var result = await DecodeReplayDtoAsync(replayPath, uploaders, token).ConfigureAwait(false);
-                    if (result.Replay is null)
+                    if (result.Import is null)
                     {
                         Interlocked.Increment(ref _errors);
                         _replayErrors.Add(new(result.Error ?? "failed decoding", replayPath));
                         return;
                     }
 
-                    await writer.WriteAsync(result.Replay, token).ConfigureAwait(false);
+                    await writer.WriteAsync(result.Import, token).ConfigureAwait(false);
                     Interlocked.Increment(ref _decoded);
                 }).ConfigureAwait(false);
         }
@@ -184,15 +185,19 @@ public sealed partial class DsstatsService
                 return new(null, "failed decoding");
             }
 
-            var dto = DsstatsParser.ParseReplay(sc2Replay);
-            if (dto is null)
+            var replayImport = DsstatsParser.ParseReplayImport(
+                sc2Replay,
+                spawnPlaybackEncoder: sidecar => SpawnPlaybackSidecarCodec.EncodeWithMetadata(
+                    sidecar,
+                    CompressionLevel.Fastest));
+            if (replayImport.Replay is null)
             {
                 return new(null, "failed parsing");
             }
 
-            dto.FileName = replayPath;
-            dto.SetUploader(uploaders);
-            return new(dto, null);
+            replayImport.Replay.FileName = replayPath;
+            replayImport.Replay.SetUploader(uploaders);
+            return new(replayImport, null);
         }
         catch (OperationCanceledException)
         {
@@ -209,10 +214,10 @@ public sealed partial class DsstatsService
     #region Import Stage (Consumer)
 
     private async Task ImportFromChannelAsync(
-        ChannelReader<ReplayDto> reader,
+        ChannelReader<ReplayImportDto> reader,
         CancellationToken ct)
     {
-        var batch = new List<ReplayDto>(ImportBatchSize);
+        var batch = new List<ReplayImportDto>(ImportBatchSize);
 
         try
         {
@@ -243,7 +248,7 @@ public sealed partial class DsstatsService
     }
 
     private async Task ImportBatchAsync(
-        List<ReplayDto> batch,
+        List<ReplayImportDto> batch,
         CancellationToken ct)
     {
         await _dbSemaphore.WaitAsync(ct).ConfigureAwait(false);
@@ -251,7 +256,7 @@ public sealed partial class DsstatsService
         {
             using var scope = scopeFactory.CreateScope();
             var importService = scope.ServiceProvider.GetRequiredService<IImportService>();
-            await importService.InsertReplays(batch).ConfigureAwait(false);
+            await importService.InsertReplayImports(batch).ConfigureAwait(false);
         }
         finally
         {
@@ -271,5 +276,5 @@ public sealed partial class DsstatsService
 
     #endregion
 
-    private sealed record DecodeReplayResult(ReplayDto? Replay, string? Error);
+    private sealed record DecodeReplayResult(ReplayImportDto? Import, string? Error);
 }

--- a/src/maui/dsstats.maui/Services/DsstatsService.Upload.cs
+++ b/src/maui/dsstats.maui/Services/DsstatsService.Upload.cs
@@ -72,7 +72,7 @@ public partial class DsstatsService
                 UploadRequestDto upload = new()
                 {
                     AppGuid = config.AppGuid,
-                    AppVersion = config.Version,
+                    AppVersion = "ma3.7",
                     RequestNames = config.Sc2Profiles
                         .Where(x => x.ToonId.Id > 0)
                         .Select(s => new RequestNames()

--- a/src/maui/dsstats.maui/Services/DsstatsService.Upload.cs
+++ b/src/maui/dsstats.maui/Services/DsstatsService.Upload.cs
@@ -91,8 +91,14 @@ public partial class DsstatsService
                         throw new InvalidOperationException("Upload succeeded but did not confirm any replay hashes.");
                     }
 
+                    var uploadedReplayIds = GetUploadedReplayIds(batch, uploadedHashes);
+                    if (uploadedReplayIds.Count == 0)
+                    {
+                        throw new InvalidOperationException("Upload succeeded but did not match any local replay hashes.");
+                    }
+
                     await context.Replays
-                        .Where(x => uploadedHashes.Contains(x.ReplayHash))
+                        .Where(x => uploadedReplayIds.Contains(x.ReplayId))
                         .ExecuteUpdateAsync(e => e.SetProperty(p => p.Uploaded, true), token)
                         .ConfigureAwait(false);
                 }
@@ -182,6 +188,7 @@ public partial class DsstatsService
         List<Replay> replays)
     {
         List<int> replayIds = new(replays.Count);
+        List<UploadReplayHash> replayHashes = new(replays.Count);
         List<ReplayDto> replayDtos = new(replays.Count);
         List<MauiUploadSidecar> sidecars = [];
 
@@ -191,8 +198,10 @@ public partial class DsstatsService
 
             var replayDto = replay.ToDto();
             replayDto.FileName = string.Empty;
+            var payloadReplayHash = replayDto.ComputeHash();
+            replayHashes.Add(new(replay.ReplayId, payloadReplayHash));
 
-            var sidecar = CreateUploadSidecar(replay, sidecars.Count);
+            var sidecar = CreateUploadSidecar(replay, payloadReplayHash, sidecars.Count);
             if (sidecar is not null)
             {
                 replayDto.SpawnPlayback = new()
@@ -219,10 +228,14 @@ public partial class DsstatsService
                 Replays = replayDtos,
             },
             replayIds,
+            replayHashes,
             sidecars);
     }
 
-    private static MauiUploadSidecar? CreateUploadSidecar(Replay replay, int sidecarIndex)
+    private static MauiUploadSidecar? CreateUploadSidecar(
+        Replay replay,
+        string payloadReplayHash,
+        int sidecarIndex)
     {
         var sidecar = replay.SpawnPlayback;
         if (sidecar is null
@@ -239,7 +252,7 @@ public partial class DsstatsService
         }
 
         return new(
-            replay.ReplayHash,
+            payloadReplayHash,
             $"sidecar-{sidecarIndex}",
             sidecar.Payload,
             sidecar.FormatVersion,
@@ -318,6 +331,15 @@ public partial class DsstatsService
         return result?.ReplayHashes.Count > 0 ? result.ReplayHashes : [];
     }
 
+    private static List<int> GetUploadedReplayIds(MauiUploadBatch batch, List<string> uploadedHashes)
+    {
+        var uploadedHashSet = uploadedHashes.ToHashSet(StringComparer.Ordinal);
+        return batch.ReplayHashes
+            .Where(replay => uploadedHashSet.Contains(replay.PayloadReplayHash))
+            .Select(replay => replay.ReplayId)
+            .ToList();
+    }
+
     private static async Task EnsureUploadSuccess(HttpResponseMessage response, CancellationToken token)
     {
         if (response.IsSuccessStatusCode)
@@ -364,7 +386,10 @@ public partial class DsstatsService
     private sealed record MauiUploadBatch(
         UploadRequestDto Request,
         List<int> ReplayIds,
+        List<UploadReplayHash> ReplayHashes,
         List<MauiUploadSidecar> Sidecars);
+
+    private sealed record UploadReplayHash(int ReplayId, string PayloadReplayHash);
 
     private sealed record MauiUploadSidecar(
         string ReplayHash,

--- a/src/maui/dsstats.maui/Services/DsstatsService.Upload.cs
+++ b/src/maui/dsstats.maui/Services/DsstatsService.Upload.cs
@@ -1,10 +1,10 @@
-﻿using dsstats.db;
+using dsstats.db;
 using dsstats.maui.Services.Models;
+using dsstats.shared;
 using dsstats.shared.Upload;
 using Microsoft.EntityFrameworkCore;
 using System.IO.Compression;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 
@@ -12,6 +12,10 @@ namespace dsstats.maui.Services;
 
 public partial class DsstatsService
 {
+    private const int SpawnPlaybackUploadBatchSize = 50;
+    private const int ReplayOnlyUploadBatchSize = 250;
+    private static readonly JsonSerializerOptions UploadJsonOptions = new(JsonSerializerDefaults.Web);
+
     public async Task<UploadResult> Upload(ImportState importState, bool force = false, CancellationToken token = default)
     {
         var result = await StartUpload(importState, force, token).ConfigureAwait(false);
@@ -30,88 +34,77 @@ public partial class DsstatsService
             });
             return new();
         }
+
         _uploadStatus = UploadStatus.Uploading;
         importState.UpdateProgress(importState.Progress with
         {
             UploadStatus = _uploadStatus,
         });
-        int take = 1000;
 
         using var scope = scopeFactory.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<DsstatsContext>();
         var httpClient = httpClientFactory.CreateClient("api");
         httpClient.DefaultRequestHeaders.Authorization = new("DS8upload77");
+        var requestNames = config.Sc2Profiles
+            .Where(x => x.ToonId.Id > 0)
+            .Select(s => new RequestNames
+            {
+                Name = s.Name,
+                ToonId = s.ToonId.Id,
+                RegionId = s.ToonId.Region,
+                RealmId = s.ToonId.Realm,
+            })
+            .ToList();
 
         try
         {
             while (!token.IsCancellationRequested)
             {
-                var replays = await context.Replays
-                    .Where(x => !x.Uploaded)
-                    .AsNoTracking()
-                    .OrderByDescending(o => o.Gametime)
-                    .Include(i => i.Players)
-                        .ThenInclude(i => i.Player)
-                    .Include(i => i.Players)
-                        .ThenInclude(i => i.Upgrades)
-                            .ThenInclude(i => i.Upgrade)
-                    .Include(i => i.Players)
-                        .ThenInclude(i => i.Spawns)
-                            .ThenInclude(i => i.Units)
-                                .ThenInclude(i => i.Unit)
-                    .AsSplitQuery()
-                        .Take(take)
-                        .ToListAsync(token)
-                        .ConfigureAwait(false);
+                var candidates = await GetUploadCandidates(context, token).ConfigureAwait(false);
+                if (candidates.Count == 0)
+                {
+                    break;
+                }
+
+                var batchCandidates = SelectUploadBatchCandidates(candidates);
+                var replays = await GetUploadReplays(
+                    context,
+                    batchCandidates.Select(candidate => candidate.ReplayId).ToList(),
+                    token).ConfigureAwait(false);
 
                 if (replays.Count == 0)
                 {
                     break;
                 }
 
-                UploadRequestDto upload = new()
+                var batch = CreateUploadBatch(config.AppGuid, requestNames, replays);
+                using var response = batch.Sidecars.Count > 0
+                    ? await PostSpawnPlaybackBatch(httpClient, batch, token).ConfigureAwait(false)
+                    : await PostReplayBatch(httpClient, batch, token).ConfigureAwait(false);
+                await EnsureUploadSuccess(response, token).ConfigureAwait(false);
+
+                if (batch.Sidecars.Count > 0)
                 {
-                    AppGuid = config.AppGuid,
-                    AppVersion = "ma3.7",
-                    RequestNames = config.Sc2Profiles
-                        .Where(x => x.ToonId.Id > 0)
-                        .Select(s => new RequestNames()
+                    var uploadedHashes = await GetUploadedHashes(response, token).ConfigureAwait(false);
+                    if (uploadedHashes.Count == 0)
                     {
-                        Name = s.Name,
-                        ToonId = s.ToonId.Id,
-                        RegionId = s.ToonId.Region,
-                        RealmId = s.ToonId.Realm,
-                    }).ToList(),
-                    Replays = replays.Select(s => s.ToDto()).ToList(),
-                };
-                upload.Replays.ForEach(f => f.FileName = string.Empty);
+                        throw new InvalidOperationException("Upload succeeded but did not confirm any replay hashes.");
+                    }
 
-                if (replays.Count > 1)
-                {
-                    var json = JsonSerializer.Serialize(upload);
-
-                    var content = new ByteArrayContent(CompressBrotli(json));
-
-                    content.Headers.ContentType =
-                        new MediaTypeHeaderValue("application/json");
-
-                    content.Headers.ContentEncoding.Add("br");
-
-                    var result = await httpClient.PostAsync("api10/Upload", content, token).ConfigureAwait(false);
-                    result.EnsureSuccessStatusCode();
+                    await context.Replays
+                        .Where(x => uploadedHashes.Contains(x.ReplayHash))
+                        .ExecuteUpdateAsync(e => e.SetProperty(p => p.Uploaded, true), token)
+                        .ConfigureAwait(false);
                 }
                 else
                 {
-                    var result = await httpClient.PostAsJsonAsync("api10/Upload", upload, token).ConfigureAwait(false);
-                    result.EnsureSuccessStatusCode();
+                    await context.Replays
+                        .Where(x => batch.ReplayIds.Contains(x.ReplayId))
+                        .ExecuteUpdateAsync(e => e.SetProperty(p => p.Uploaded, true), token)
+                        .ConfigureAwait(false);
                 }
-
-                var replayIds = replays.Select(s => s.ReplayId).ToList();
-                await context.Replays
-                    .Where(x => replayIds.Contains(x.ReplayId))
-                    .ExecuteUpdateAsync(e => e.SetProperty(p => p.Uploaded, true))
-                    .ConfigureAwait(false);
             }
+
             _uploadStatus = UploadStatus.Success;
             importState.UpdateProgress(importState.Progress with
             {
@@ -138,22 +131,225 @@ public partial class DsstatsService
         }
     }
 
-    static byte[] Compress(string text)
+    private static async Task<List<UploadReplayCandidate>> GetUploadCandidates(
+        DsstatsContext context,
+        CancellationToken token)
     {
-        var bytes = Encoding.UTF8.GetBytes(text);
+        return await context.Replays
+            .Where(x => !x.Uploaded)
+            .AsNoTracking()
+            .OrderByDescending(o => o.Gametime)
+            .Select(x => new UploadReplayCandidate(x.ReplayId, x.SpawnPlayback != null))
+            .Take(ReplayOnlyUploadBatchSize)
+            .ToListAsync(token)
+            .ConfigureAwait(false);
+    }
 
+    private static List<UploadReplayCandidate> SelectUploadBatchCandidates(List<UploadReplayCandidate> candidates)
+    {
+        return candidates.Any(candidate => candidate.HasSidecar)
+            ? candidates.Take(SpawnPlaybackUploadBatchSize).ToList()
+            : candidates;
+    }
+
+    private static async Task<List<Replay>> GetUploadReplays(
+        DsstatsContext context,
+        List<int> replayIds,
+        CancellationToken token)
+    {
+        return await context.Replays
+            .Where(x => replayIds.Contains(x.ReplayId))
+            .AsNoTracking()
+            .OrderByDescending(o => o.Gametime)
+            .Include(i => i.SpawnPlayback)
+            .Include(i => i.Players)
+                .ThenInclude(i => i.Player)
+            .Include(i => i.Players)
+                .ThenInclude(i => i.Upgrades)
+                    .ThenInclude(i => i.Upgrade)
+            .Include(i => i.Players)
+                .ThenInclude(i => i.Spawns)
+                    .ThenInclude(i => i.Units)
+                        .ThenInclude(i => i.Unit)
+            .AsSplitQuery()
+            .ToListAsync(token)
+            .ConfigureAwait(false);
+    }
+
+    private static MauiUploadBatch CreateUploadBatch(
+        Guid appGuid,
+        List<RequestNames> requestNames,
+        List<Replay> replays)
+    {
+        List<int> replayIds = new(replays.Count);
+        List<ReplayDto> replayDtos = new(replays.Count);
+        List<MauiUploadSidecar> sidecars = [];
+
+        foreach (var replay in replays)
+        {
+            replayIds.Add(replay.ReplayId);
+
+            var replayDto = replay.ToDto();
+            replayDto.FileName = string.Empty;
+
+            var sidecar = CreateUploadSidecar(replay, sidecars.Count);
+            if (sidecar is not null)
+            {
+                replayDto.SpawnPlayback = new()
+                {
+                    Available = true,
+                    FormatVersion = sidecar.FormatVersion,
+                    Compression = sidecar.Compression,
+                    CompressedLength = sidecar.CompressedLength,
+                    UncompressedLength = sidecar.UncompressedLength,
+                    UnitCount = sidecar.UnitCount,
+                };
+                sidecars.Add(sidecar);
+            }
+
+            replayDtos.Add(replayDto);
+        }
+
+        return new(
+            new UploadRequestDto
+            {
+                AppGuid = appGuid,
+                AppVersion = "ma3.7",
+                RequestNames = requestNames,
+                Replays = replayDtos,
+            },
+            replayIds,
+            sidecars);
+    }
+
+    private static MauiUploadSidecar? CreateUploadSidecar(Replay replay, int sidecarIndex)
+    {
+        var sidecar = replay.SpawnPlayback;
+        if (sidecar is null
+            || sidecar.Payload.Length == 0
+            || sidecar.CompressedLength != sidecar.Payload.Length
+            || sidecar.FormatVersion != SpawnPlaybackSidecarCodec.FormatVersion
+            || sidecar.CompressedLength <= 0
+            || sidecar.UncompressedLength <= 0
+            || sidecar.UnitCount <= 0
+            || sidecar.Compression is not (SpawnPlaybackCompression.Brotli or SpawnPlaybackCompression.GZip)
+            || !SpawnPlaybackEligibility.IsEligible(replay.Players.Count, replay.Duration))
+        {
+            return null;
+        }
+
+        return new(
+            replay.ReplayHash,
+            $"sidecar-{sidecarIndex}",
+            sidecar.Payload,
+            sidecar.FormatVersion,
+            sidecar.Compression,
+            sidecar.CompressedLength,
+            sidecar.UncompressedLength,
+            sidecar.UnitCount);
+    }
+
+    private static async Task<HttpResponseMessage> PostReplayBatch(
+        HttpClient httpClient,
+        MauiUploadBatch batch,
+        CancellationToken token)
+    {
+        var compressedRequest = CompressBrotli(SerializeUploadRequest(batch.Request));
+        using var content = new ByteArrayContent(compressedRequest);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        content.Headers.ContentEncoding.Add("br");
+        content.Headers.ContentLength = compressedRequest.Length;
+
+        return await httpClient.PostAsync("api10/Upload", content, token).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpResponseMessage> PostSpawnPlaybackBatch(
+        HttpClient httpClient,
+        MauiUploadBatch batch,
+        CancellationToken token)
+    {
+        using var multipart = new MultipartFormDataContent();
+
+        var compressedRequest = CompressGZip(SerializeUploadRequest(batch.Request));
+        var requestContent = new ByteArrayContent(compressedRequest);
+        requestContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        requestContent.Headers.ContentEncoding.Add("gzip");
+        requestContent.Headers.ContentLength = compressedRequest.Length;
+        multipart.Add(requestContent, "request", "request.json.gz");
+
+        var manifest = batch.Sidecars
+            .Select(sidecar => new SpawnPlaybackUploadManifestEntryDto
+            {
+                ReplayHash = sidecar.ReplayHash,
+                PartName = sidecar.PartName,
+                FormatVersion = sidecar.FormatVersion,
+                Compression = sidecar.Compression,
+                CompressedLength = sidecar.CompressedLength,
+                UncompressedLength = sidecar.UncompressedLength,
+                UnitCount = sidecar.UnitCount,
+            })
+            .ToList();
+
+        multipart.Add(
+            new StringContent(JsonSerializer.Serialize(manifest, UploadJsonOptions), Encoding.UTF8, "application/json"),
+            "manifest");
+
+        foreach (var sidecar in batch.Sidecars)
+        {
+            var sidecarContent = new ByteArrayContent(sidecar.Payload);
+            sidecarContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            sidecarContent.Headers.ContentLength = sidecar.Payload.Length;
+            multipart.Add(sidecarContent, sidecar.PartName, $"{sidecar.PartName}.bin");
+        }
+
+        return await httpClient.PostAsync("api10/upload/import-spawn-playbacks", multipart, token).ConfigureAwait(false);
+    }
+
+    private static async Task<List<string>> GetUploadedHashes(
+        HttpResponseMessage response,
+        CancellationToken token)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
+        var result = await JsonSerializer.DeserializeAsync<ReplayImportBatchResultDto>(
+            stream,
+            UploadJsonOptions,
+            token).ConfigureAwait(false);
+
+        return result?.ReplayHashes.Count > 0 ? result.ReplayHashes : [];
+    }
+
+    private static async Task EnsureUploadSuccess(HttpResponseMessage response, CancellationToken token)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var body = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+        var message = string.IsNullOrWhiteSpace(body)
+            ? $"Upload failed with {(int)response.StatusCode} {response.ReasonPhrase}."
+            : $"Upload failed with {(int)response.StatusCode} {response.ReasonPhrase}: {body}";
+        throw new HttpRequestException(message, null, response.StatusCode);
+    }
+
+    private static byte[] SerializeUploadRequest(UploadRequestDto request)
+    {
+        return JsonSerializer.SerializeToUtf8Bytes(request, UploadJsonOptions);
+    }
+
+    private static byte[] CompressGZip(byte[] bytes)
+    {
         using var ms = new MemoryStream();
-        using (var gz = new GZipStream(ms, CompressionLevel.Fastest))
+        using (var gz = new GZipStream(ms, CompressionLevel.Fastest, leaveOpen: true))
         {
             gz.Write(bytes, 0, bytes.Length);
         }
+
         return ms.ToArray();
     }
 
-    static byte[] CompressBrotli(string text)
+    private static byte[] CompressBrotli(byte[] bytes)
     {
-        var bytes = Encoding.UTF8.GetBytes(text);
-
         using var ms = new MemoryStream();
         using (var br = new BrotliStream(ms, CompressionLevel.Fastest, leaveOpen: true))
         {
@@ -162,4 +358,21 @@ public partial class DsstatsService
 
         return ms.ToArray();
     }
+
+    private sealed record UploadReplayCandidate(int ReplayId, bool HasSidecar);
+
+    private sealed record MauiUploadBatch(
+        UploadRequestDto Request,
+        List<int> ReplayIds,
+        List<MauiUploadSidecar> Sidecars);
+
+    private sealed record MauiUploadSidecar(
+        string ReplayHash,
+        string PartName,
+        byte[] Payload,
+        ushort FormatVersion,
+        SpawnPlaybackCompression Compression,
+        int CompressedLength,
+        int UncompressedLength,
+        int UnitCount);
 }

--- a/src/tests/dsstats.tests/SpawnPlaybackImportService.Tests.cs
+++ b/src/tests/dsstats.tests/SpawnPlaybackImportService.Tests.cs
@@ -1,5 +1,6 @@
 using dsstats.db;
 using dsstats.dbServices;
+using dsstats.parser;
 using dsstats.shared;
 using dsstats.shared.Interfaces;
 using dsstats.shared.Upload;
@@ -15,6 +16,39 @@ namespace dsstats.tests;
 [TestClass]
 public sealed class SpawnPlaybackImportServiceTests
 {
+    [TestMethod]
+    [DeploymentItem("testdata/Direct Strike (8607).SC2Replay")]
+    public async Task ParseReplayImport_WithFastestBrotliSidecar_StoresPayload()
+    {
+        using var serviceProvider = BuildServiceProvider(out var connection);
+        try
+        {
+            var sc2Replay = await DsstatsParser.GetSc2Replay("Direct Strike (8607).SC2Replay");
+            Assert.IsNotNull(sc2Replay);
+
+            var replayImport = DsstatsParser.ParseReplayImport(
+                sc2Replay,
+                spawnPlaybackEncoder: sidecar => SpawnPlaybackSidecarCodec.EncodeWithMetadata(
+                    sidecar,
+                    CompressionLevel.Fastest));
+            Assert.IsNotNull(replayImport.SpawnPlayback);
+
+            var importService = serviceProvider.GetRequiredService<IImportService>();
+            await importService.InsertReplayImports([replayImport]);
+
+            var stored = await GetOnlySidecar(serviceProvider);
+            Assert.AreEqual(SpawnPlaybackCompression.Brotli, stored.Compression);
+            Assert.AreEqual(replayImport.SpawnPlayback.CompressedLength, stored.CompressedLength);
+            Assert.AreEqual(replayImport.SpawnPlayback.UncompressedLength, stored.UncompressedLength);
+            Assert.AreEqual(replayImport.SpawnPlayback.UnitCount, stored.UnitCount);
+            CollectionAssert.AreEqual(replayImport.SpawnPlayback.Payload, stored.Payload);
+        }
+        finally
+        {
+            connection.Dispose();
+        }
+    }
+
     [TestMethod]
     public async Task InsertReplayImports_NewReplayWithSidecar_StoresPayload()
     {


### PR DESCRIPTION
## Summary
- Add MAUI spawn playback sidecar storage during replay import.
- Upload stored sidecars through the existing multipart spawn playback endpoint.
- Use DTO-computed upload hashes for sidecar manifests and uploaded-row confirmation.
- Reduce upload memory and database work with candidate-first batching.

## Validation
- dotnet test src/tests/dsstats.tests/dsstats.tests.sln passed: 276 tests.
- dotnet build src/maui/dsstats.maui/dsstats.maui.csproj passed.

Note: the MAUI build still reports the existing CS9113 warning in DatabaseService.cs for an unread constructor parameter.