### PR TITLE
[codex] add top rated replays dashboard

### DIFF
--- a/src/common/dsstats.shared/ReplayDto.cs
+++ b/src/common/dsstats.shared/ReplayDto.cs
@@ -129,6 +129,8 @@ public class ReplayListDto
     public double? Exp2Win { get; init; }
     public int? AvgRating { get; init; }
     public LeaverType LeaverType { get; init; }
+    public int? ReplayUserVoteCount { get; init; }
+    public double? ReplayUserScore { get; init; }
     public int PlayerPos { get; set; }
     public double PlayerGain { get; set; }
 }

--- a/src/common/dsstats.shared/ReplaysRequest.cs
+++ b/src/common/dsstats.shared/ReplaysRequest.cs
@@ -21,7 +21,7 @@ public class ReplaysRequest
 
 public class ReplaysFilter
 {
-    public FilterRange<DateTime>? DateRange { get; set; }
+    public TimePeriod TimePeriod { get; set; } = TimePeriod.AllTime;
     public int Playercount { get; set; }
     public bool TournamentEdition { get; set; }
     public bool RatedOnly { get; set; }
@@ -31,7 +31,7 @@ public class ReplaysFilter
 
     public void Reset()
     {
-        DateRange = null;
+        TimePeriod = TimePeriod.AllTime;
         Playercount = 0;
         TournamentEdition = false;
         RatedOnly = false;

--- a/src/common/dsstats.shared/ReplaysRequest.cs
+++ b/src/common/dsstats.shared/ReplaysRequest.cs
@@ -24,6 +24,7 @@ public class ReplaysFilter
     public int Playercount { get; set; }
     public bool TournamentEdition { get; set; }
     public bool RatedOnly { get; set; }
+    public bool WithSpawnPlayback { get; set; }
     public List<GameMode> GameModes { get; set; } = [];
     public List<ReplaysPosFilter> PosFilters { get; set; } = [];
 
@@ -32,6 +33,7 @@ public class ReplaysFilter
         Playercount = 0;
         TournamentEdition = false;
         RatedOnly = false;
+        WithSpawnPlayback = false;
         GameModes = new() { GameMode.None };
         PosFilters.Clear();
     }

--- a/src/common/dsstats.shared/ReplaysRequest.cs
+++ b/src/common/dsstats.shared/ReplaysRequest.cs
@@ -21,6 +21,7 @@ public class ReplaysRequest
 
 public class ReplaysFilter
 {
+    public FilterRange<DateTime>? DateRange { get; set; }
     public int Playercount { get; set; }
     public bool TournamentEdition { get; set; }
     public bool RatedOnly { get; set; }
@@ -30,6 +31,7 @@ public class ReplaysFilter
 
     public void Reset()
     {
+        DateRange = null;
         Playercount = 0;
         TournamentEdition = false;
         RatedOnly = false;

--- a/src/common/dsstats.shared/ReplaysRequest.cs
+++ b/src/common/dsstats.shared/ReplaysRequest.cs
@@ -13,6 +13,7 @@ public class ReplaysRequest
     public int PageSize { get; set; } = 20_000;
     public int Skip { get; set; }
     public int Take { get; set; }
+    public bool IncludeReplayUserRatings { get; set; }
     public ReplaysFilter? Filter { get; set; }
     [JsonIgnore]
     public string? ReplayHash { get; set; }
@@ -22,6 +23,7 @@ public class ReplaysFilter
 {
     public int Playercount { get; set; }
     public bool TournamentEdition { get; set; }
+    public bool RatedOnly { get; set; }
     public List<GameMode> GameModes { get; set; } = [];
     public List<ReplaysPosFilter> PosFilters { get; set; } = [];
 
@@ -29,6 +31,7 @@ public class ReplaysFilter
     {
         Playercount = 0;
         TournamentEdition = false;
+        RatedOnly = false;
         GameModes = new() { GameMode.None };
         PosFilters.Clear();
     }

--- a/src/common/dsstats.weblib/Dashboard/DashboardComponent.razor
+++ b/src/common/dsstats.weblib/Dashboard/DashboardComponent.razor
@@ -44,6 +44,19 @@
 
 	<StatsComponent />
 
+	<div class="row mt-2">
+		<div class="col-auto bgchart p-3 rounded border">
+			<h4 class="text-warning">Top Rated Replays</h4>
+			<small>Past 90 days - User ratings</small>
+			<TopReplays />
+			<div class="text-end mt-1">
+				<a class="text-decoration-none" href="/replays">
+					View all replays →
+				</a>
+			</div>
+		</div>
+	</div>
+
 	<h3 class="mt-2 fw-bold text-warning d-inline-block p-2 bgchart border border-dark rounded">Ressources</h3>
 	<div class="row mt-2">
 		<div class="col-auto bgchart p-2 ms-2 border rounded mt-1">

--- a/src/common/dsstats.weblib/Dashboard/TopCommanders.razor
+++ b/src/common/dsstats.weblib/Dashboard/TopCommanders.razor
@@ -35,7 +35,7 @@
 			{
 				@foreach (var ent in response.WinrateEnts.Take(7))
 				{
-					<tr>
+					<tr class="text-nowrap">
 						<td>
 							<div class="d-flex">
 								<div class="preload-@(ent.Commander.ToString().ToLower())"></div>

--- a/src/common/dsstats.weblib/Dashboard/TopReplays.razor
+++ b/src/common/dsstats.weblib/Dashboard/TopReplays.razor
@@ -109,10 +109,7 @@
 			Filter = new()
 			{
 				RatedOnly = true,
-				DateRange = new()
-				{
-					From = DateTime.Today.AddDays(-90)
-				}
+				TimePeriod = TimePeriod.Last90Days
 			},
 			TableOrders =
 			[

--- a/src/common/dsstats.weblib/Dashboard/TopReplays.razor
+++ b/src/common/dsstats.weblib/Dashboard/TopReplays.razor
@@ -1,0 +1,145 @@
+@using dsstats.shared
+@using dsstats.shared.Interfaces
+@using dsstats.weblib.Replays
+@inject IReplayRepository ReplayRepository
+@inject NavigationManager NavigationManager
+
+<div class="table-responsive">
+	<table class="tptable top-replays-table" aria-busy="@isLoading">
+		<colgroup>
+			<col class="top-replays-date" />
+			<col class="top-replays-mode" />
+			<col class="top-replays-duration" />
+			<col class="top-replays-score" />
+			<col class="top-replays-votes" />
+			<col class="top-replays-team" />
+			<col class="top-replays-team" />
+		</colgroup>
+		<thead class="user-select-none">
+			<tr>
+				<th>Gametime</th>
+				<th class="top-replays-mode-cell">Mode</th>
+				<th>Duration</th>
+				<th>Score</th>
+				<th class="top-replays-votes-cell">Votes</th>
+				<th class="top-replays-team-cell">Team1</th>
+				<th class="top-replays-team-cell">Team2</th>
+			</tr>
+		</thead>
+		<tbody role="status">
+			@if (isLoading)
+			{
+				@for (int i = 0; i < 7; i++)
+				{
+					<tr class="placeholder-wave">
+						<td><span class="placeholder w-100"></span></td>
+						<td class="top-replays-mode-cell"><span class="placeholder w-100 bg-warning"></span></td>
+						<td><span class="placeholder w-100"></span></td>
+						<td><span class="placeholder w-100 bg-warning"></span></td>
+						<td class="top-replays-votes-cell"><span class="placeholder w-100"></span></td>
+						<td class="top-replays-team-cell"><span class="placeholder w-100 bg-primary"></span></td>
+						<td class="top-replays-team-cell"><span class="placeholder w-100"></span></td>
+					</tr>
+				}
+			}
+			else
+			{
+				@foreach (var replay in replays)
+				{
+					<tr class="pointer text-nowrap" @onclick="() => NavigationManager.NavigateTo(GetReplayUrl(replay))">
+						<td>
+							@replay.Gametime.ToString("yyyy-MM-dd")
+						</td>
+						<td class="top-replays-mode-cell">@replay.GameMode</td>
+						<td>@TimeSpan.FromSeconds(replay.Duration).ToString(@"hh\:mm\:ss")</td>
+						<td class="text-warning text-nowrap" title="@replay.ReplayUserScore?.ToString("N2")">
+							@if (replay.ReplayUserScore is double score)
+							{
+								@for (var i = 1; i <= 5; i++)
+								{
+									<i class="bi @GetReplayUserRatingStarClass(score, i)"></i>
+								}
+							}
+							else
+							{
+								<span>-</span>
+							}
+						</td>
+						<td class="top-replays-votes-cell">@(replay.ReplayUserVoteCount?.ToString("N0") ?? "-")</td>
+						<td class="top-replays-team-cell">
+							<div style="width: 104px;">
+								<ReplayTeamComponent Replay="replay" TeamNumber="1" />
+							</div>
+						</td>
+						<td class="top-replays-team-cell">
+							<div style="width: 104px;">
+								<ReplayTeamComponent Replay="replay" TeamNumber="2" />
+							</div>
+						</td>
+					</tr>
+				}
+			}
+		</tbody>
+	</table>
+</div>
+
+@code {
+	bool isLoading = true;
+	List<ReplayListDto> replays = [];
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			await LoadData();
+			isLoading = false;
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task LoadData()
+	{
+		ReplaysRequest request = new()
+		{
+			IncludeReplayUserRatings = true,
+			Page = 1,
+			PageSize = 7,
+			Skip = 0,
+			Take = 7,
+			Filter = new()
+			{
+				RatedOnly = true,
+				DateRange = new()
+				{
+					From = DateTime.Today.AddDays(-90)
+				}
+			},
+			TableOrders =
+			[
+				new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = false }
+			]
+		};
+
+		replays = await ReplayRepository.GetReplays(request);
+	}
+
+	private static string GetReplayUrl(ReplayListDto replay)
+	{
+		return $"/replays?Replay={Uri.EscapeDataString(replay.ReplayHash)}";
+	}
+
+	private static string GetCommanders(ReplayListDto replay)
+	{
+		return $"{string.Join(", ", replay.CommandersTeam1)} vs {string.Join(", ", replay.CommandersTeam2)}";
+	}
+
+	private static string GetReplayUserRatingStarClass(double score, int star)
+	{
+		if (score >= star - 0.25)
+		{
+			return "bi-star-fill";
+		}
+
+		return score >= star - 0.75 ? "bi-star-half" : "bi-star";
+	}
+}

--- a/src/common/dsstats.weblib/Dashboard/TopReplays.razor.css
+++ b/src/common/dsstats.weblib/Dashboard/TopReplays.razor.css
@@ -1,0 +1,52 @@
+.top-replays-table {
+    min-width: 720px;
+}
+
+.top-replays-date {
+    width: 98px;
+}
+
+.top-replays-mode {
+    width: 110px;
+}
+
+.top-replays-duration {
+    width: 86px;
+}
+
+.top-replays-score {
+    width: 96px;
+}
+
+.top-replays-votes {
+    width: 64px;
+}
+
+.top-replays-team {
+    width: 128px;
+}
+
+@media (max-width: 575.98px) {
+    .top-replays-table {
+        min-width: 100%;
+        font-size: 0.875rem;
+    }
+
+    .top-replays-date {
+        width: 94px;
+    }
+
+    .top-replays-duration {
+        width: 78px;
+    }
+
+    .top-replays-score {
+        width: 74px;
+    }
+
+    .top-replays-mode-cell,
+    .top-replays-votes-cell,
+    .top-replays-team-cell {
+        display: none;
+    }
+}

--- a/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
+++ b/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
@@ -40,6 +40,11 @@
 							<InputCheckbox class="form-check-input" @bind-Value="filter.RatedOnly" />
 							<label class="form-check-label">Rated replays only</label>
 						</div>
+
+						<div class="form-check mb-3">
+							<InputCheckbox class="form-check-input" @bind-Value="filter.WithSpawnPlayback" />
+							<label class="form-check-label">With playback only</label>
+						</div>
 					}
 
 					<!-- Game Modes -->

--- a/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
+++ b/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
@@ -34,6 +34,14 @@
 						<label class="form-check-label">Tournament Edition</label>
 					</div>
 
+					@if (IsServerHost)
+					{
+						<div class="form-check mb-3">
+							<InputCheckbox class="form-check-input" @bind-Value="filter.RatedOnly" />
+							<label class="form-check-label">Rated replays only</label>
+						</div>
+					}
+
 					<!-- Game Modes -->
 					<div class="mb-3">
 						<label class="form-label">Game Modes</label>
@@ -153,6 +161,7 @@
 	public ReplaysFilter filter = new();
 	private EditContext editContext = null!;
 
+	[Parameter] public bool IsServerHost { get; set; }
 	[Parameter] public EventCallback<ReplaysFilter?> OnRequest { get; set; }
 	[Parameter] public EventCallback OnClose { get; set; }
 

--- a/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
+++ b/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
@@ -16,6 +16,17 @@
 					<DataAnnotationsValidator />
 					<ValidationSummary />
 
+					<!-- Time Period -->
+					<div class="mb-3">
+						<label class="form-label">Time Period</label>
+						<InputSelect class="form-select" @bind-Value="filter.TimePeriod">
+							@foreach (var timePeriod in Data.GetBasicTimePeriods())
+							{
+								<option value="@timePeriod">@Data.GetTimePeriodInfo(timePeriod).Name</option>
+							}
+						</InputSelect>
+					</div>
+
 					<!-- Player Count -->
 					<div class="mb-3">
 						<label class="form-label">Player Count</label>

--- a/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
+++ b/src/common/dsstats.weblib/Replays/ReplayFiliterModal.razor
@@ -16,16 +16,19 @@
 					<DataAnnotationsValidator />
 					<ValidationSummary />
 
-					<!-- Time Period -->
-					<div class="mb-3">
-						<label class="form-label">Time Period</label>
-						<InputSelect class="form-select" @bind-Value="filter.TimePeriod">
-							@foreach (var timePeriod in Data.GetBasicTimePeriods())
-							{
-								<option value="@timePeriod">@Data.GetTimePeriodInfo(timePeriod).Name</option>
-							}
-						</InputSelect>
-					</div>
+					@if (IsServerHost)
+					{
+						<!-- Time Period -->
+						<div class="mb-3">
+							<label class="form-label">Time Period</label>
+							<InputSelect class="form-select" @bind-Value="filter.TimePeriod">
+								@foreach (var timePeriod in Data.GetBasicTimePeriods())
+								{
+									<option value="@timePeriod">@Data.GetTimePeriodInfo(timePeriod).Name</option>
+								}
+							</InputSelect>
+						</div>
+					}
 
 					<!-- Player Count -->
 					<div class="mb-3">
@@ -65,8 +68,7 @@
 							@foreach (var gm in Enum.GetValues<GameMode>())
 							{
 								<div class="form-check">
-									<input type="checkbox" class="form-check-input"
-										   checked="@filter.GameModes.Contains(gm)"
+									<input type="checkbox" class="form-check-input" checked="@filter.GameModes.Contains(gm)"
 										   @onchange="() => ToggleGameMode(gm)" />
 									<label class="form-check-label">@gm.ToString()</label>
 								</div>
@@ -84,9 +86,11 @@
 									<div class="d-flex justify-content-between align-items-center">
 										<div>
 											<label>Position (0 = Any)</label>
-											<InputNumber class="form-control" min="0" max="6" step="1" @bind-Value="pos.GamePos" />
+											<InputNumber class="form-control" min="0" max="6" step="1"
+														 @bind-Value="pos.GamePos" />
 										</div>
-										<button type="button" class="btn btn-sm btn-danger" @onclick="@(() => RemovePosFilter(pos))">Remove</button>
+										<button type="button" class="btn btn-sm btn-danger"
+												@onclick="@(() => RemovePosFilter(pos))">Remove</button>
 									</div>
 
 									<div class="mt-2">
@@ -153,24 +157,26 @@
 												</div>
 											</div>
 										}
-										<button type="button" class="btn btn-sm btn-outline-primary" @onclick="@(() => AddUnitFilter(pos))">+ Add Unit Filter</button>
+										<button type="button" class="btn btn-sm btn-outline-primary"
+												@onclick="@(() => AddUnitFilter(pos))">+ Add Unit Filter</button>
 									</div>
 								</div>
 							}
-							<button type="button" class="btn btn-outline-primary" @onclick="AddPosFilter">+ Add Position Filter</button>
+							<button type="button" class="btn btn-outline-primary" @onclick="AddPosFilter">+ Add Position
+								Filter</button>
+							</div>
 						</div>
-					</div>
 
-					<div class="d-flex justify-content-end gap-2 mt-4 bgchart2">
-						<button type="button" class="btn btn-secondary" @onclick="Close">Cancel</button>
-						<button type="submit" class="btn btn-success">Apply</button>
-						<button type="button" class="btn btn-warning" @onclick="ResetFilter">Reset</button>
-					</div>
-				</EditForm>
+						<div class="d-flex justify-content-end gap-2 mt-4 bgchart2">
+							<button type="button" class="btn btn-secondary" @onclick="Close">Cancel</button>
+							<button type="submit" class="btn btn-success">Apply</button>
+							<button type="button" class="btn btn-warning" @onclick="ResetFilter">Reset</button>
+						</div>
+					</EditForm>
+				</div>
 			</div>
 		</div>
 	</div>
-</div>
 
 @code {
 	private string modalId = "replayFilterModal";

--- a/src/common/dsstats.weblib/Replays/ReplaysComponent.razor
+++ b/src/common/dsstats.weblib/Replays/ReplaysComponent.razor
@@ -1,27 +1,34 @@
 ﻿@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.Extensions.Options
 @using Microsoft.JSInterop
 @using dsstats.shared
 @using dsstats.shared.Interfaces
 @using dsstats.weblib.Players
 @inject IReplayRepository ReplayRepository
 @inject IJSRuntime JSRuntime
+@inject IOptions<HostOptions> HostOptions
 @implements IDisposable
 
 <div>
 	<div style="max-width: 1060px;">
 		<ReplaysRequestComponent Request="ReplaysRequest" ReplaysCount="replaysCount" IsLoading="isLoading" OnRequestChanged="Reload" />
 	</div>
-	<div class="table-responsive" style="max-height: 76vh; max-width: 1060px; overflow-x: auto; overflow-y: auto;">
+	<div class="table-responsive" style="max-height: 76vh; max-width: 1160px; overflow-x: auto; overflow-y: auto;">
 		<table class="tptable">
 			<colgroup>
-				<col width="12%" />
-				<col width="20%" />
-				<col width="10%" />
-				<col width="17.5%" />
-				<col width="17.5%" />
+				<col width="11%" />
+				<col width="15%" />
+				<col width="8%" />
+				<col width="15%" />
+				<col width="15%" />
 				<col width="6%" />
-				<col width="5%" />
-				<col width="12%" />
+				<col width="6%" />
+				@if (IsServerHost)
+				{
+					<col width="5%" />
+					<col width="10%" />
+				}
+				<col width="9%" />
 			</colgroup>
 			<CascadingValue Value="ReplaysRequest.TableOrders">
 				<thead class="user-select-none">
@@ -47,6 +54,15 @@
 						<th scope="col" class="pointer" @onclick="@(e => SortList(e, "AvgRating"))">
 							<SortArrow Column="AvgRating">AvgRating</SortArrow>
 						</th>
+						@if (IsServerHost)
+						{
+							<th scope="col" class="pointer" @onclick="@(e => SortList(e, nameof(ReplayListDto.ReplayUserVoteCount)))">
+								<SortArrow Column="@nameof(ReplayListDto.ReplayUserVoteCount)">Votes</SortArrow>
+							</th>
+							<th scope="col" class="pointer" @onclick="@(e => SortList(e, nameof(ReplayListDto.ReplayUserScore)))">
+								<SortArrow Column="@nameof(ReplayListDto.ReplayUserScore)">Score</SortArrow>
+							</th>
+						}
 						<th scope="col" class="pointer" @onclick="@(e => SortList(e, "LeaverType"))">
 							<SortArrow Column="LeaverType">LeaverType</SortArrow>
 						</th>
@@ -71,6 +87,25 @@
 								</td>
 								<td class="@(replay.Exp2Win >= 0.5 ? "text-success" : "text-danger")">@replay.Exp2Win?.ToString("p0")</td>
 								<td>@replay.AvgRating</td>
+								@if (IsServerHost)
+								{
+									<td>@(replay.ReplayUserVoteCount?.ToString("N0") ?? "-")</td>
+									<td>
+										@if (replay.ReplayUserScore is double score)
+										{
+											<span class="text-warning text-nowrap" title="@score.ToString("N2")">
+												@for (var i = 1; i <= 5; i++)
+												{
+													<i class="bi @GetReplayUserRatingStarClass(score, i)"></i>
+												}
+											</span>
+										}
+										else
+										{
+											<span>-</span>
+										}
+									</td>
+								}
 								<td>@replay.LeaverType</td>
 							</tr>
 						</ItemContent>
@@ -112,6 +147,7 @@
 	ReplayModal? replayModal;
 	PlayerModal? playerModal;
 	bool isLoading = true;
+	bool IsServerHost => HostOptions.Value.Kind == HostAppKind.BlazorServer;
 
 	protected override void OnInitialized()
 	{
@@ -130,6 +166,7 @@
 
 	private async Task SetCount()
 	{
+		SetReplayUserRatingRequestOptions();
 		replaysCount = await ReplayRepository.GetReplaysCount(ReplaysRequest);
 		isLoading = false;
 		await InvokeAsync(StateHasChanged);
@@ -139,6 +176,7 @@
 	{
 		isLoading = true;
 		await InvokeAsync(StateHasChanged);
+		SetReplayUserRatingRequestOptions();
 		replaysCount = await ReplayRepository.GetReplaysCount(ReplaysRequest);
 		ReplaysRequest.Page = 1;
 		if (virtualizeComponent != null)
@@ -158,6 +196,7 @@
 		var numReplays = Math.Min(request.Count, replaysCount - request.StartIndex);
 		ReplaysRequest.Skip = request.StartIndex;
 		ReplaysRequest.Take = numReplays;
+		SetReplayUserRatingRequestOptions();
 		var replays = await ReplayRepository.GetReplays(ReplaysRequest, request.CancellationToken);
 		latestResponse = replays;
 		return new ItemsProviderResult<ReplayListDto>(replays, Math.Min(replaysCount, ReplaysRequest.PageSize));
@@ -204,6 +243,11 @@
 		}
 	}
 
+	private void SetReplayUserRatingRequestOptions()
+	{
+		ReplaysRequest.IncludeReplayUserRatings = IsServerHost;
+	}
+
 	private void CloseReplay()
 	{
 		ReplayDetails = null;
@@ -245,6 +289,16 @@
 		await JSRuntime.InvokeVoidAsync("scrollToElementId", newElement?.ReplayHash);
 
 		await LoadReplay(newElement?.ReplayHash ?? "");
+	}
+
+	private static string GetReplayUserRatingStarClass(double score, int star)
+	{
+		if (score >= star - 0.25)
+		{
+			return "bi-star-fill";
+		}
+
+		return score >= star - 0.75 ? "bi-star-half" : "bi-star";
 	}
 
 	public void Dispose()

--- a/src/common/dsstats.weblib/Replays/ReplaysRequestComponent.razor
+++ b/src/common/dsstats.weblib/Replays/ReplaysRequestComponent.razor
@@ -1,5 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.Extensions.Options
 @using dsstats.shared
+@inject IOptions<HostOptions> HostOptions
 @implements IDisposable
 
 <div class="bgchart rounded p-2 mb-2">
@@ -121,7 +123,7 @@
 	</EditForm>
 </div>
 
-<ReplayFiliterModal @ref="replayFiliterModal" OnRequest="FilterRequest" />
+<ReplayFiliterModal @ref="replayFiliterModal" IsServerHost="IsServerHost" OnRequest="FilterRequest" />
 
 @code {
 	[Parameter, EditorRequired]
@@ -138,6 +140,7 @@
 
 	ReplayFiliterModal? replayFiliterModal;
 	EditContext editContext = null!;
+	bool IsServerHost => HostOptions.Value.Kind == HostAppKind.BlazorServer;
 
 	private int TotalPages => Request.PageSize > 0 ? (int)Math.Ceiling((double)ReplaysCount / Request.PageSize) : 1;
 

--- a/src/server/dsstats.api/Program.cs
+++ b/src/server/dsstats.api/Program.cs
@@ -208,8 +208,8 @@ dbContext.Database.Migrate();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    //var ratingsService = scope.ServiceProvider.GetRequiredService<IRatingService>();
-    //ratingsService.CreateRatings().Wait();
+    var replayUserRatingService = scope.ServiceProvider.GetRequiredService<ReplayUserRatingService>();
+    replayUserRatingService.CollectPendingVotesAsync().Wait();
 }
 
 app.Use(async (httpContext, next) =>

--- a/src/server/dsstats.dbServices/ReplayRepository.cs
+++ b/src/server/dsstats.dbServices/ReplayRepository.cs
@@ -404,13 +404,11 @@ public partial class ReplayRepository(
 
     private static string GetTopReplaysMemKey(ReplaysRequest request)
     {
-        var dateRange = request.Filter?.DateRange;
         return "topReplays_"
             + $"{request.RatingType}_"
             + $"{request.PageSize}_"
             + $"{request.Take}_"
-            + $"{dateRange?.From:yyyyMMdd}_"
-            + $"{dateRange?.To:yyyyMMdd}";
+            + $"{request.Filter?.TimePeriod}";
     }
 
     public async Task<int> GetReplaysCount(ReplaysRequest request, CancellationToken token = default)
@@ -730,16 +728,14 @@ public partial class ReplayRepository(
             return ApplyPlayerSearchFilters(query, request);
         }
 
-        if (request.Filter.DateRange is { } dateRange)
+        if (request.Filter.TimePeriod is not TimePeriod.None and not TimePeriod.AllTime and not TimePeriod.Custom)
         {
-            if (dateRange.From != default)
-            {
-                query = query.Where(x => x.Gametime >= dateRange.From);
-            }
+            var timeInfo = Data.GetTimePeriodInfo(request.Filter.TimePeriod);
+            query = query.Where(x => x.Gametime >= timeInfo.Start);
 
-            if (dateRange.To != default)
+            if (timeInfo.HasEnd)
             {
-                query = query.Where(x => x.Gametime <= dateRange.To);
+                query = query.Where(x => x.Gametime <= timeInfo.End);
             }
         }
 

--- a/src/server/dsstats.dbServices/ReplayRepository.cs
+++ b/src/server/dsstats.dbServices/ReplayRepository.cs
@@ -685,6 +685,12 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
                 .Any(s => s.ReplayId == r.ReplayId && s.VoteCount > 0));
         }
 
+        if (request.Filter.WithSpawnPlayback)
+        {
+            query = query.Where(r => context.ReplaySpawnPlaybacks
+                .Any(s => s.ReplayId == r.ReplayId));
+        }
+
         if (request.Filter.GameModes.Count > 0
             && !request.Filter.GameModes.Contains(GameMode.None))
         {

--- a/src/server/dsstats.dbServices/ReplayRepository.cs
+++ b/src/server/dsstats.dbServices/ReplayRepository.cs
@@ -3,11 +3,15 @@ using dsstats.shared;
 using dsstats.shared.Interfaces;
 using LinqKit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace dsstats.dbServices;
 
-public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextFactory, ILogger<ReplayRepository> logger) : IReplayRepository
+public partial class ReplayRepository(
+    IDbContextFactory<DsstatsContext> contextFactory,
+    IMemoryCache memoryCache,
+    ILogger<ReplayRepository> logger) : IReplayRepository
 {
     public async Task<ReplayDetails?> GetReplayDetails(string replayHash)
     {
@@ -310,6 +314,33 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
 
     public async Task<List<ReplayListDto>> GetReplays(ReplaysRequest request, CancellationToken token = default)
     {
+        if (IsTopReplaysRequest(request))
+        {
+            return await GetTopReplays(request, token);
+        }
+
+        return await GetReplaysUncached(request, token);
+    }
+
+    private async Task<List<ReplayListDto>> GetTopReplays(ReplaysRequest request, CancellationToken token)
+    {
+        var memKey = GetTopReplaysMemKey(request);
+        if (memoryCache.TryGetValue(memKey, out var value)
+            && value is List<ReplayListDto> items)
+        {
+            return items;
+        }
+
+        items = await GetReplaysUncached(request, token);
+        if (items.Count > 0)
+        {
+            memoryCache.Set(memKey, items, TimeSpan.FromHours(1));
+        }
+        return items;
+    }
+
+    private async Task<List<ReplayListDto>> GetReplaysUncached(ReplaysRequest request, CancellationToken token = default)
+    {
         await using var context = await contextFactory.CreateDbContextAsync(token);
         try
         {
@@ -350,6 +381,36 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
             logger.LogError("Error getting replays: {error}", ex.Message);
         }
         return [];
+    }
+
+    private static bool IsTopReplaysRequest(ReplaysRequest request)
+    {
+        var filter = request.Filter;
+        return request.PageSize < 10
+            && request.Page == 1
+            && request.Skip == 0
+            && request.IncludeReplayUserRatings
+            && filter?.RatedOnly == true
+            && request.TableOrders is [{ Column: nameof(ReplayListDto.ReplayUserScore), Ascending: false }]
+            && string.IsNullOrWhiteSpace(request.Name)
+            && string.IsNullOrWhiteSpace(request.Commander)
+            && !request.LinkCommanders
+            && filter.Playercount == 0
+            && !filter.TournamentEdition
+            && !filter.WithSpawnPlayback
+            && filter.GameModes.Count == 0
+            && filter.PosFilters.Count == 0;
+    }
+
+    private static string GetTopReplaysMemKey(ReplaysRequest request)
+    {
+        var dateRange = request.Filter?.DateRange;
+        return "topReplays_"
+            + $"{request.RatingType}_"
+            + $"{request.PageSize}_"
+            + $"{request.Take}_"
+            + $"{dateRange?.From:yyyyMMdd}_"
+            + $"{dateRange?.To:yyyyMMdd}";
     }
 
     public async Task<int> GetReplaysCount(ReplaysRequest request, CancellationToken token = default)
@@ -667,6 +728,19 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
         if (request.Filter is null)
         {
             return ApplyPlayerSearchFilters(query, request);
+        }
+
+        if (request.Filter.DateRange is { } dateRange)
+        {
+            if (dateRange.From != default)
+            {
+                query = query.Where(x => x.Gametime >= dateRange.From);
+            }
+
+            if (dateRange.To != default)
+            {
+                query = query.Where(x => x.Gametime <= dateRange.To);
+            }
         }
 
         if (request.Filter.Playercount != 0)

--- a/src/server/dsstats.dbServices/ReplayRepository.cs
+++ b/src/server/dsstats.dbServices/ReplayRepository.cs
@@ -322,9 +322,14 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
 
             var filteredReplays = GetFilteredReplays(request, context);
             bool requiresRatingJoin = RequiresRatingJoin(request);
-            IQueryable<ReplayList> query = requiresRatingJoin
-                ? GetReplaysQueriableWithRatings(filteredReplays, context, request.RatingType)
-                : GetReplaysQueriable(filteredReplays);
+            bool requiresReplayUserRatingJoin = RequiresReplayUserRatingJoin(request);
+            IQueryable<ReplayList> query = (requiresRatingJoin, requiresReplayUserRatingJoin) switch
+            {
+                (true, true) => GetReplaysQueriableWithRatingsAndReplayUserRatings(filteredReplays, context, request.RatingType),
+                (true, false) => GetReplaysQueriableWithRatings(filteredReplays, context, request.RatingType),
+                (false, true) => GetReplaysQueriableWithReplayUserRatings(filteredReplays, context),
+                _ => GetReplaysQueriable(filteredReplays)
+            };
 
             IOrderedQueryable<ReplayList> ordered = GetOrderedReplays(query, request);
             List<ReplayList> list = await ordered
@@ -405,9 +410,42 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
                         ? (order.Ascending ? query.OrderBy(x => x.Exp2Win ?? 0) : query.OrderByDescending(x => x.Exp2Win ?? 0))
                         : (order.Ascending ? orderedQuery.ThenBy(x => x.Exp2Win ?? 0) : orderedQuery.ThenByDescending(x => x.Exp2Win ?? 0));
                     break;
+                case nameof(ReplayListDto.ReplayUserVoteCount):
+                    orderedQuery = orderedQuery == null
+                        ? (order.Ascending ? query.OrderBy(x => x.ReplayUserVoteCount ?? 0) : query.OrderByDescending(x => x.ReplayUserVoteCount ?? 0))
+                        : (order.Ascending ? orderedQuery.ThenBy(x => x.ReplayUserVoteCount ?? 0) : orderedQuery.ThenByDescending(x => x.ReplayUserVoteCount ?? 0));
+                    break;
+                case nameof(ReplayListDto.ReplayUserScore):
+                    orderedQuery = ApplyReplayUserScoreOrdering(query, orderedQuery, order.Ascending);
+                    break;
             }
         }
         return orderedQuery ?? query.OrderByDescending(x => x.GameTime);
+    }
+
+    private static IOrderedQueryable<ReplayList> ApplyReplayUserScoreOrdering(
+        IQueryable<ReplayList> query,
+        IOrderedQueryable<ReplayList>? orderedQuery,
+        bool ascending)
+    {
+        if (orderedQuery is null)
+        {
+            return ascending
+                ? query.OrderBy(x => x.ReplayUserScore ?? 0)
+                    .ThenBy(x => x.ReplayUserVoteCount ?? 0)
+                    .ThenBy(x => x.GameTime)
+                : query.OrderByDescending(x => x.ReplayUserScore ?? 0)
+                    .ThenByDescending(x => x.ReplayUserVoteCount ?? 0)
+                    .ThenByDescending(x => x.GameTime);
+        }
+
+        return ascending
+            ? orderedQuery.ThenBy(x => x.ReplayUserScore ?? 0)
+                .ThenBy(x => x.ReplayUserVoteCount ?? 0)
+                .ThenBy(x => x.GameTime)
+            : orderedQuery.ThenByDescending(x => x.ReplayUserScore ?? 0)
+                .ThenByDescending(x => x.ReplayUserVoteCount ?? 0)
+                .ThenByDescending(x => x.GameTime);
     }
 
     private static bool RequiresRatingJoin(ReplaysRequest request)
@@ -416,6 +454,15 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
             nameof(ReplayList.LeaverType) or
             nameof(ReplayList.AvgRating) or
             nameof(ReplayList.Exp2Win)) == true;
+    }
+
+    private static bool RequiresReplayUserRatingJoin(ReplaysRequest request)
+    {
+        return request.IncludeReplayUserRatings
+            || request.Filter?.RatedOnly == true
+            || request.TableOrders?.Any(order => order.Column is
+                nameof(ReplayListDto.ReplayUserVoteCount) or
+                nameof(ReplayListDto.ReplayUserScore)) == true;
     }
 
     private static IQueryable<ReplayList> GetReplaysQueriable(IQueryable<Replay> replays)
@@ -462,6 +509,68 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
                    Exp2Win = rr == null ? null : rr.ExpectedWinProbability,
                    AvgRating = rr == null ? null : rr.AvgRating,
                    LeaverType = rr == null ? LeaverType.None : rr.LeaverType,
+               };
+    }
+
+    private static IQueryable<ReplayList> GetReplaysQueriableWithReplayUserRatings(IQueryable<Replay> replays, DsstatsContext context)
+    {
+        return from r in replays
+               from urs in context.ReplayUserRatingSummaries
+                   .AsNoTracking()
+                   .Where(x => x.ReplayId == r.ReplayId)
+                   .DefaultIfEmpty()
+               select new ReplayList()
+               {
+                   ReplayId = r.ReplayId,
+                   ReplayHash = r.ReplayHash,
+                   GameTime = r.Gametime,
+                   GameMode = r.GameMode,
+                   Duration = r.Duration,
+                   WinnerTeam = r.WinnerTeam,
+                   Players = r.Players.Select(s => new ReplayPlayerList()
+                   {
+                       Name = s.Name,
+                       Race = s.Race,
+                       Team = s.TeamId,
+                   }).ToList(),
+                   ReplayUserVoteCount = urs == null || urs.VoteCount <= 0 ? null : urs.VoteCount,
+                   ReplayUserScore = urs == null || urs.VoteCount <= 0 ? null : urs.ScoreSum / (double)urs.VoteCount,
+               };
+    }
+
+    private static IQueryable<ReplayList> GetReplaysQueriableWithRatingsAndReplayUserRatings(
+        IQueryable<Replay> replays,
+        DsstatsContext context,
+        RatingType ratingType)
+    {
+        return from r in replays
+               from rr in context.ReplayRatings
+                   .AsNoTracking()
+                   .Where(x => x.ReplayId == r.ReplayId && x.RatingType == ratingType)
+                   .DefaultIfEmpty()
+               from urs in context.ReplayUserRatingSummaries
+                   .AsNoTracking()
+                   .Where(x => x.ReplayId == r.ReplayId)
+                   .DefaultIfEmpty()
+               select new ReplayList()
+               {
+                   ReplayId = r.ReplayId,
+                   ReplayHash = r.ReplayHash,
+                   GameTime = r.Gametime,
+                   GameMode = r.GameMode,
+                   Duration = r.Duration,
+                   WinnerTeam = r.WinnerTeam,
+                   Players = r.Players.Select(s => new ReplayPlayerList()
+                   {
+                       Name = s.Name,
+                       Race = s.Race,
+                       Team = s.TeamId,
+                   }).ToList(),
+                   Exp2Win = rr == null ? null : rr.ExpectedWinProbability,
+                   AvgRating = rr == null ? null : rr.AvgRating,
+                   LeaverType = rr == null ? LeaverType.None : rr.LeaverType,
+                   ReplayUserVoteCount = urs == null || urs.VoteCount <= 0 ? null : urs.VoteCount,
+                   ReplayUserScore = urs == null || urs.VoteCount <= 0 ? null : urs.ScoreSum / (double)urs.VoteCount,
                };
     }
 
@@ -568,6 +677,12 @@ public partial class ReplayRepository(IDbContextFactory<DsstatsContext> contextF
         if (request.Filter.TournamentEdition)
         {
             query = query.Where(x => x.TE);
+        }
+
+        if (request.Filter.RatedOnly)
+        {
+            query = query.Where(r => context.ReplayUserRatingSummaries
+                .Any(s => s.ReplayId == r.ReplayId && s.VoteCount > 0));
         }
 
         if (request.Filter.GameModes.Count > 0
@@ -691,6 +806,8 @@ internal sealed class ReplayList
     public double? Exp2Win { get; set; }
     public int? AvgRating { get; set; }
     public LeaverType LeaverType { get; set; }
+    public int? ReplayUserVoteCount { get; set; }
+    public double? ReplayUserScore { get; set; }
 
     public ReplayListDto GetDto()
     {
@@ -706,6 +823,8 @@ internal sealed class ReplayList
             Exp2Win = Exp2Win,
             AvgRating = AvgRating,
             LeaverType = LeaverType,
+            ReplayUserVoteCount = ReplayUserVoteCount,
+            ReplayUserScore = ReplayUserScore,
             PlayerPos = PlayerPos,
         };
     }

--- a/src/tests/dsstats.tests/ReplayRepository.Tests.cs
+++ b/src/tests/dsstats.tests/ReplayRepository.Tests.cs
@@ -3,6 +3,7 @@ using dsstats.dbServices;
 using dsstats.shared;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -171,6 +172,88 @@ public sealed class ReplayRepositoryTests
         Assert.AreEqual("hash-1", replays[0].ReplayHash);
         Assert.AreEqual(2, replays[0].ReplayUserVoteCount);
         Assert.AreEqual(4.0, replays[0].ReplayUserScore);
+    }
+
+    [TestMethod]
+    public async Task GetReplays_DateRange_ComposesWithRatedOnly()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 2, 24),
+            replayUserVoteCount: 10,
+            replayUserScoreSum: 50);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 2,
+            gametime: new DateTime(2026, 2, 25),
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 8);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 3,
+            gametime: new DateTime(2026, 5, 26));
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 4,
+            gametime: new DateTime(2026, 5, 20),
+            replayUserVoteCount: 0,
+            replayUserScoreSum: 0);
+
+        var request = new ReplaysRequest
+        {
+            IncludeReplayUserRatings = true,
+            Filter = new()
+            {
+                RatedOnly = true,
+                DateRange = new()
+                {
+                    From = new DateTime(2026, 2, 25)
+                }
+            },
+            Take = 10,
+            TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = false }]
+        };
+
+        var count = await fixture.Repository.GetReplaysCount(request);
+        var replays = await fixture.Repository.GetReplays(request);
+
+        Assert.AreEqual(1, count);
+        Assert.AreEqual(1, replays.Count);
+        Assert.AreEqual("hash-2", replays[0].ReplayHash);
+        Assert.AreEqual(2, replays[0].ReplayUserVoteCount);
+        Assert.AreEqual(4.0, replays[0].ReplayUserScore);
+    }
+
+    [TestMethod]
+    public async Task GetReplays_TopRatedLandingPageRequest_UsesCache()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 5, 1),
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 8);
+
+        var request = CreateTopRatedReplaysRequest();
+
+        var first = await fixture.Repository.GetReplays(request);
+
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 2,
+            gametime: new DateTime(2026, 5, 2),
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 10);
+
+        var second = await fixture.Repository.GetReplays(request);
+
+        Assert.AreEqual(1, first.Count);
+        Assert.AreEqual("hash-1", first[0].ReplayHash);
+        Assert.AreEqual(1, second.Count);
+        Assert.AreEqual("hash-1", second[0].ReplayHash);
     }
 
     [TestMethod]
@@ -363,6 +446,27 @@ public sealed class ReplayRepositoryTests
         Assert.AreEqual("hash-1", replays[0].ReplayHash);
     }
 
+    private static ReplaysRequest CreateTopRatedReplaysRequest()
+    {
+        return new()
+        {
+            IncludeReplayUserRatings = true,
+            Page = 1,
+            PageSize = 7,
+            Skip = 0,
+            Take = 7,
+            Filter = new()
+            {
+                RatedOnly = true,
+                DateRange = new()
+                {
+                    From = new DateTime(2026, 2, 25)
+                }
+            },
+            TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = false }]
+        };
+    }
+
     private static async Task SeedReplayAsync(
         DsstatsContext context,
         int replayId,
@@ -502,6 +606,7 @@ public sealed class ReplayRepositoryTests
             Context = context;
             Repository = new ReplayRepository(
                 serviceProvider.GetRequiredService<IDbContextFactory<DsstatsContext>>(),
+                serviceProvider.GetRequiredService<IMemoryCache>(),
                 NullLogger<ReplayRepository>.Instance);
         }
 
@@ -516,6 +621,7 @@ public sealed class ReplayRepositoryTests
             await connection.OpenAsync();
 
             var services = new ServiceCollection();
+            services.AddMemoryCache();
             services.AddDbContextFactory<DsstatsContext>(options => options.UseSqlite(connection, sqlite =>
                 sqlite.MigrationsAssembly("dsstats.migrations.sqlite")));
 

--- a/src/tests/dsstats.tests/ReplayRepository.Tests.cs
+++ b/src/tests/dsstats.tests/ReplayRepository.Tests.cs
@@ -108,6 +108,158 @@ public sealed class ReplayRepositoryTests
     }
 
     [TestMethod]
+    public async Task GetReplays_DefaultGameTimeSort_LoadsReplayUserRatingsOnlyWhenRequested()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 5, 1),
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 8);
+
+        var defaultReplays = await fixture.Repository.GetReplays(new ReplaysRequest
+        {
+            RatingType = RatingType.Commanders,
+            Take = 10
+        });
+
+        Assert.IsNull(defaultReplays[0].ReplayUserVoteCount);
+        Assert.IsNull(defaultReplays[0].ReplayUserScore);
+
+        var requestedReplays = await fixture.Repository.GetReplays(new ReplaysRequest
+        {
+            RatingType = RatingType.Commanders,
+            IncludeReplayUserRatings = true,
+            Take = 10
+        });
+
+        Assert.AreEqual(2, requestedReplays[0].ReplayUserVoteCount);
+        Assert.AreEqual(4.0, requestedReplays[0].ReplayUserScore);
+    }
+
+    [TestMethod]
+    public async Task GetReplays_RatedOnly_ExcludesUnratedAndZeroVoteReplays()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 5, 1),
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 8);
+        await SeedReplayAsync(fixture.Context, replayId: 2, gametime: new DateTime(2026, 5, 2));
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 3,
+            gametime: new DateTime(2026, 5, 3),
+            replayUserVoteCount: 0,
+            replayUserScoreSum: 0);
+
+        var request = new ReplaysRequest
+        {
+            IncludeReplayUserRatings = true,
+            Filter = new() { RatedOnly = true },
+            Take = 10
+        };
+
+        var count = await fixture.Repository.GetReplaysCount(request);
+        var replays = await fixture.Repository.GetReplays(request);
+
+        Assert.AreEqual(1, count);
+        Assert.AreEqual(1, replays.Count);
+        Assert.AreEqual("hash-1", replays[0].ReplayHash);
+        Assert.AreEqual(2, replays[0].ReplayUserVoteCount);
+        Assert.AreEqual(4.0, replays[0].ReplayUserScore);
+    }
+
+    [TestMethod]
+    public async Task GetReplays_SortsByReplayUserVoteCount()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 5, 1),
+            replayUserVoteCount: 1,
+            replayUserScoreSum: 5);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 2,
+            gametime: new DateTime(2026, 5, 2),
+            replayUserVoteCount: 5,
+            replayUserScoreSum: 20);
+
+        var ascending = await fixture.Repository.GetReplays(new ReplaysRequest
+        {
+            Filter = new() { RatedOnly = true },
+            Take = 10,
+            TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserVoteCount), Ascending = true }]
+        });
+
+        CollectionAssert.AreEqual(
+            new[] { "hash-1", "hash-2" },
+            ascending.Select(s => s.ReplayHash).ToArray());
+
+        var descending = await fixture.Repository.GetReplays(new ReplaysRequest
+        {
+            Filter = new() { RatedOnly = true },
+            Take = 10,
+            TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserVoteCount), Ascending = false }]
+        });
+
+        CollectionAssert.AreEqual(
+            new[] { "hash-2", "hash-1" },
+            descending.Select(s => s.ReplayHash).ToArray());
+    }
+
+    [TestMethod]
+    public async Task GetReplays_SortsByReplayUserScoreThenVoteCountAndGameTime()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 5, 1),
+            replayUserVoteCount: 1,
+            replayUserScoreSum: 5);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 2,
+            gametime: new DateTime(2026, 5, 2),
+            replayUserVoteCount: 3,
+            replayUserScoreSum: 15);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 3,
+            gametime: new DateTime(2026, 5, 3),
+            replayUserVoteCount: 10,
+            replayUserScoreSum: 45);
+
+        var descending = await fixture.Repository.GetReplays(new ReplaysRequest
+        {
+            Filter = new() { RatedOnly = true },
+            Take = 10,
+            TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = false }]
+        });
+
+        CollectionAssert.AreEqual(
+            new[] { "hash-2", "hash-1", "hash-3" },
+            descending.Select(s => s.ReplayHash).ToArray());
+
+        var ascending = await fixture.Repository.GetReplays(new ReplaysRequest
+        {
+            Filter = new() { RatedOnly = true },
+            Take = 10,
+            TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = true }]
+        });
+
+        CollectionAssert.AreEqual(
+            new[] { "hash-3", "hash-1", "hash-2" },
+            ascending.Select(s => s.ReplayHash).ToArray());
+    }
+
+    [TestMethod]
     public async Task GetReplays_NameFilter_DoesNotDuplicateReplayRows()
     {
         await using var fixture = await TestFixture.CreateAsync();
@@ -145,6 +297,8 @@ public sealed class ReplayRepositoryTests
         int avgRating = 1500,
         double exp2Win = 0.50,
         bool seedRating = true,
+        int? replayUserVoteCount = null,
+        int replayUserScoreSum = 0,
         string[]? playerNames = null)
     {
         playerNames ??= ["PlayerA", "PlayerB", "PlayerC", "PlayerD", "PlayerE", "PlayerF"];
@@ -231,6 +385,18 @@ public sealed class ReplayRepositoryTests
                 ExpectedWinProbability = exp2Win,
                 AvgRating = avgRating,
                 ReplayId = replayId
+            });
+        }
+
+        if (replayUserVoteCount.HasValue)
+        {
+            context.ReplayUserRatingSummaries.Add(new ReplayUserRatingSummary
+            {
+                ReplayUserRatingSummaryId = replayId * 100,
+                ReplayId = replayId,
+                VoteCount = replayUserVoteCount.Value,
+                ScoreSum = replayUserScoreSum,
+                UpdatedAt = gametime
             });
         }
 

--- a/src/tests/dsstats.tests/ReplayRepository.Tests.cs
+++ b/src/tests/dsstats.tests/ReplayRepository.Tests.cs
@@ -174,6 +174,80 @@ public sealed class ReplayRepositoryTests
     }
 
     [TestMethod]
+    public async Task GetReplays_WithSpawnPlayback_ExcludesReplaysWithoutSpawnPlayback()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 5, 1),
+            seedSpawnPlayback: true);
+        await SeedReplayAsync(fixture.Context, replayId: 2, gametime: new DateTime(2026, 5, 2));
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 3,
+            gametime: new DateTime(2026, 5, 3),
+            seedSpawnPlayback: true);
+
+        var request = new ReplaysRequest
+        {
+            Filter = new() { WithSpawnPlayback = true },
+            Take = 10
+        };
+
+        var count = await fixture.Repository.GetReplaysCount(request);
+        var replays = await fixture.Repository.GetReplays(request);
+
+        Assert.AreEqual(2, count);
+        CollectionAssert.AreEqual(
+            new[] { "hash-3", "hash-1" },
+            replays.Select(s => s.ReplayHash).ToArray());
+    }
+
+    [TestMethod]
+    public async Task GetReplays_WithSpawnPlayback_ComposesWithRatedOnly()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: new DateTime(2026, 5, 1),
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 8,
+            seedSpawnPlayback: true);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 2,
+            gametime: new DateTime(2026, 5, 2),
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 10);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 3,
+            gametime: new DateTime(2026, 5, 3),
+            seedSpawnPlayback: true);
+
+        var request = new ReplaysRequest
+        {
+            IncludeReplayUserRatings = true,
+            Filter = new()
+            {
+                RatedOnly = true,
+                WithSpawnPlayback = true
+            },
+            Take = 10
+        };
+
+        var count = await fixture.Repository.GetReplaysCount(request);
+        var replays = await fixture.Repository.GetReplays(request);
+
+        Assert.AreEqual(1, count);
+        Assert.AreEqual(1, replays.Count);
+        Assert.AreEqual("hash-1", replays[0].ReplayHash);
+        Assert.AreEqual(2, replays[0].ReplayUserVoteCount);
+    }
+
+    [TestMethod]
     public async Task GetReplays_SortsByReplayUserVoteCount()
     {
         await using var fixture = await TestFixture.CreateAsync();
@@ -299,6 +373,7 @@ public sealed class ReplayRepositoryTests
         bool seedRating = true,
         int? replayUserVoteCount = null,
         int replayUserScoreSum = 0,
+        bool seedSpawnPlayback = false,
         string[]? playerNames = null)
     {
         playerNames ??= ["PlayerA", "PlayerB", "PlayerC", "PlayerD", "PlayerE", "PlayerF"];
@@ -397,6 +472,21 @@ public sealed class ReplayRepositoryTests
                 VoteCount = replayUserVoteCount.Value,
                 ScoreSum = replayUserScoreSum,
                 UpdatedAt = gametime
+            });
+        }
+
+        if (seedSpawnPlayback)
+        {
+            context.ReplaySpawnPlaybacks.Add(new ReplaySpawnPlayback
+            {
+                ReplayId = replayId,
+                FormatVersion = SpawnPlaybackSidecarCodec.FormatVersion,
+                Compression = SpawnPlaybackCompression.Brotli,
+                CompressedLength = 3,
+                UncompressedLength = 10,
+                UnitCount = 1,
+                Payload = [1, 2, 3],
+                CreatedAt = gametime
             });
         }
 

--- a/src/tests/dsstats.tests/ReplayRepository.Tests.cs
+++ b/src/tests/dsstats.tests/ReplayRepository.Tests.cs
@@ -175,29 +175,30 @@ public sealed class ReplayRepositoryTests
     }
 
     [TestMethod]
-    public async Task GetReplays_DateRange_ComposesWithRatedOnly()
+    public async Task GetReplays_TimePeriod_ComposesWithRatedOnly()
     {
         await using var fixture = await TestFixture.CreateAsync();
+        var timeInfo = Data.GetTimePeriodInfo(TimePeriod.Last90Days);
         await SeedReplayAsync(
             fixture.Context,
             replayId: 1,
-            gametime: new DateTime(2026, 2, 24),
+            gametime: timeInfo.Start.AddDays(-1),
             replayUserVoteCount: 10,
             replayUserScoreSum: 50);
         await SeedReplayAsync(
             fixture.Context,
             replayId: 2,
-            gametime: new DateTime(2026, 2, 25),
+            gametime: timeInfo.Start,
             replayUserVoteCount: 2,
             replayUserScoreSum: 8);
         await SeedReplayAsync(
             fixture.Context,
             replayId: 3,
-            gametime: new DateTime(2026, 5, 26));
+            gametime: timeInfo.Start.AddDays(1));
         await SeedReplayAsync(
             fixture.Context,
             replayId: 4,
-            gametime: new DateTime(2026, 5, 20),
+            gametime: timeInfo.Start.AddDays(2),
             replayUserVoteCount: 0,
             replayUserScoreSum: 0);
 
@@ -207,10 +208,7 @@ public sealed class ReplayRepositoryTests
             Filter = new()
             {
                 RatedOnly = true,
-                DateRange = new()
-                {
-                    From = new DateTime(2026, 2, 25)
-                }
+                TimePeriod = TimePeriod.Last90Days
             },
             Take = 10,
             TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = false }]
@@ -227,13 +225,53 @@ public sealed class ReplayRepositoryTests
     }
 
     [TestMethod]
-    public async Task GetReplays_TopRatedLandingPageRequest_UsesCache()
+    public async Task GetReplays_AllTimeTimePeriod_DoesNotFilterByDate()
     {
         await using var fixture = await TestFixture.CreateAsync();
+        var timeInfo = Data.GetTimePeriodInfo(TimePeriod.Last90Days);
         await SeedReplayAsync(
             fixture.Context,
             replayId: 1,
-            gametime: new DateTime(2026, 5, 1),
+            gametime: timeInfo.Start.AddDays(-1),
+            replayUserVoteCount: 10,
+            replayUserScoreSum: 50);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 2,
+            gametime: timeInfo.Start,
+            replayUserVoteCount: 2,
+            replayUserScoreSum: 8);
+
+        var request = new ReplaysRequest
+        {
+            IncludeReplayUserRatings = true,
+            Filter = new()
+            {
+                RatedOnly = true,
+                TimePeriod = TimePeriod.AllTime
+            },
+            Take = 10,
+            TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = false }]
+        };
+
+        var count = await fixture.Repository.GetReplaysCount(request);
+        var replays = await fixture.Repository.GetReplays(request);
+
+        Assert.AreEqual(2, count);
+        CollectionAssert.AreEqual(
+            new[] { "hash-1", "hash-2" },
+            replays.Select(s => s.ReplayHash).ToArray());
+    }
+
+    [TestMethod]
+    public async Task GetReplays_TopRatedLandingPageRequest_UsesCache()
+    {
+        await using var fixture = await TestFixture.CreateAsync();
+        var timeInfo = Data.GetTimePeriodInfo(TimePeriod.Last90Days);
+        await SeedReplayAsync(
+            fixture.Context,
+            replayId: 1,
+            gametime: timeInfo.Start,
             replayUserVoteCount: 2,
             replayUserScoreSum: 8);
 
@@ -244,7 +282,7 @@ public sealed class ReplayRepositoryTests
         await SeedReplayAsync(
             fixture.Context,
             replayId: 2,
-            gametime: new DateTime(2026, 5, 2),
+            gametime: timeInfo.Start.AddDays(1),
             replayUserVoteCount: 2,
             replayUserScoreSum: 10);
 
@@ -458,10 +496,7 @@ public sealed class ReplayRepositoryTests
             Filter = new()
             {
                 RatedOnly = true,
-                DateRange = new()
-                {
-                    From = new DateTime(2026, 2, 25)
-                }
+                TimePeriod = TimePeriod.Last90Days
             },
             TableOrders = [new() { Column = nameof(ReplayListDto.ReplayUserScore), Ascending = false }]
         };


### PR DESCRIPTION
## Summary
- add a Top Rated Replays dashboard card with responsive mobile layout
- support replay user rating score/vote sorting and rated-only filtering
- add replay TimePeriod filtering through the replay filter modal
- cache the landing-page top replay query for small dashboard requests

## Validation
- dotnet test src/tests/dsstats.tests/dsstats.tests.sln