### PR TITLE
[codex] Queue spawn playback uploads

### DIFF
--- a/src/server/dsstats.api/Controllers/UploadController.cs
+++ b/src/server/dsstats.api/Controllers/UploadController.cs
@@ -1,27 +1,18 @@
 using dsstats.api.Services;
-using dsstats.dbServices;
 using dsstats.shared;
 using dsstats.shared.Interfaces;
 using dsstats.shared.Upload;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
-using System.IO.Compression;
-using System.Text.Json;
 
 namespace dsstats.api.Controllers;
 
 [ApiController]
 [Route("api10/[controller]")]
-[Route("api8/v1/[controller]")] // DEBUG
 [ServiceFilter(typeof(AuthenticationFilterAttribute))]
 public class UploadController(
-    UploadService uploadService,
-    IImportService importService,
-    ILogger<UploadController> logger) : Controller
+    UploadService uploadService) : Controller
 {
-    private static readonly JsonSerializerOptions UploadJsonOptions = new(JsonSerializerDefaults.Web);
-
     [HttpPost]
     [RequestSizeLimit(1024000000)]
     [Route("ImportReplays")]
@@ -53,7 +44,6 @@ public class UploadController(
     [EnableRateLimiting("fixed")]
     public async Task<ActionResult<DecodeRequestResult>> UploadReplay(string guid, [FromForm] IFormFile file)
     {
-        logger.LogInformation("indahouse");
         if (Guid.TryParse(guid, out var fileGuid))
         {
             var result = await uploadService.SaveReplay(fileGuid, file);
@@ -82,50 +72,22 @@ public class UploadController(
         [FromForm] int unitCount,
         CancellationToken token)
     {
-        if (sidecar.Length == 0)
-        {
-            return BadRequest("Invalid sidecar payload.");
-        }
-
-        var replayDto = JsonSerializer.Deserialize<ReplayDto>(replay);
-        if (replayDto is null)
-        {
-            return BadRequest("Invalid replay payload.");
-        }
-
-        using var payload = new MemoryStream((int)sidecar.Length);
-        await sidecar.CopyToAsync(payload, token);
-        var bytes = payload.ToArray();
-        if (bytes.Length != compressedLength)
-        {
-            return BadRequest("Sidecar compressed length does not match payload length.");
-        }
-        if (formatVersion != SpawnPlaybackSidecarCodec.FormatVersion
-            || compressedLength <= 0
-            || uncompressedLength <= 0
-            || unitCount <= 0)
-        {
-            return BadRequest("Invalid sidecar metadata.");
-        }
-        if (!ImportService.IsSupportedCompression(compression))
-        {
-            return BadRequest("Unsupported sidecar compression.");
-        }
-
-        var encodedSidecar = new SpawnPlaybackEncodedSidecar(
-            bytes,
+        var result = await uploadService.ProcessSpawnPlaybackUploadAsync(
+            replay,
+            sidecar,
+            formatVersion,
+            compression,
             compressedLength,
             uncompressedLength,
             unitCount,
-            formatVersion,
-            compression);
+            token);
 
-        await importService.InsertReplayImports([new(replayDto, encodedSidecar)]);
-        return Ok(new ReplayImportResultDto
+        if (!result.Success)
         {
-            Success = true,
-            ReplayHash = replayDto.ComputeHash()
-        });
+            return BadRequest(result.Error);
+        }
+
+        return Ok(result);
     }
 
     [HttpPost]
@@ -141,78 +103,10 @@ public class UploadController(
         [FromForm] string? manifest,
         CancellationToken token)
     {
-        if (request is null || request.Length == 0)
-        {
-            return BadRequest("Invalid replay payload.");
-        }
-
-        UploadRequestDto? uploadRequest;
-        try
-        {
-            await using var requestStream = request.OpenReadStream();
-            await using var gzip = new GZipStream(requestStream, CompressionMode.Decompress);
-            uploadRequest = await JsonSerializer.DeserializeAsync<UploadRequestDto>(
-                gzip,
-                UploadJsonOptions,
-                token);
-        }
-        catch (InvalidDataException ex)
-        {
-            logger.LogWarning(ex, "Failed to decompress spawn playback import request.");
-            return BadRequest("Invalid replay payload gzip stream.");
-        }
-        catch (JsonException ex)
-        {
-            logger.LogWarning(ex, "Failed to deserialize spawn playback import request.");
-            return BadRequest("Invalid replay payload json.");
-        }
-
-        if (uploadRequest is null)
-        {
-            return BadRequest("Invalid replay payload.");
-        }
-
-        if (string.IsNullOrWhiteSpace(manifest))
-        {
-            return BadRequest("Missing sidecar manifest.");
-        }
-
-        List<SpawnPlaybackUploadManifestEntryDto> manifestEntries;
-        try
-        {
-            manifestEntries = JsonSerializer.Deserialize<List<SpawnPlaybackUploadManifestEntryDto>>(
-                manifest,
-                UploadJsonOptions) ?? [];
-        }
-        catch (JsonException ex)
-        {
-            logger.LogWarning(ex, "Failed to deserialize spawn playback import manifest.");
-            return BadRequest("Invalid sidecar manifest json.");
-        }
-
-        var payloadsByPartName = new Dictionary<string, SpawnPlaybackUploadPayload>(StringComparer.Ordinal);
-        foreach (var file in HttpContext.Request.Form.Files)
-        {
-            if (string.Equals(file.Name, "request", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var payload = new SpawnPlaybackUploadPayload(
-                file.Name,
-                file.Length,
-                file.OpenReadStream);
-
-            if (!payloadsByPartName.TryAdd(file.Name, payload))
-            {
-                return BadRequest("Duplicate sidecar payload.");
-            }
-        }
-
-        var result = await importService.InsertReplayImportsWithSidecars(
-            uploadRequest,
-            manifestEntries,
-            payloadsByPartName,
+        var result = await uploadService.ProcessSpawnPlaybackUploadAsync(
+            request,
+            manifest,
+            HttpContext.Request.Form.Files,
             token);
 
         if (!result.Success)

--- a/src/server/dsstats.api/Program.cs
+++ b/src/server/dsstats.api/Program.cs
@@ -123,6 +123,7 @@ builder.Services.AddRateLimiter(options =>
 
 builder.Services.AddDbConfig(builder.Configuration);
 builder.Services.AddUploadChannels();
+builder.Services.Configure<UploadStorageOptions>(builder.Configuration.GetSection(UploadStorageOptions.SectionName));
 builder.Services.Configure<InHouseAuthOptions>(builder.Configuration.GetSection(InHouseAuthOptions.SectionName));
 builder.Services.AddOptions<ReplayUserRatingOptions>()
     .Bind(builder.Configuration.GetSection("ReplayUserRating"));

--- a/src/server/dsstats.api/Services/SpawnPlaybackUploadPackage.cs
+++ b/src/server/dsstats.api/Services/SpawnPlaybackUploadPackage.cs
@@ -1,0 +1,18 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace dsstats.api.Services;
+
+internal static class SpawnPlaybackUploadPackage
+{
+    public const string RequestFileName = "request.json.gz";
+    public const string ManifestFileName = "manifest.json";
+    public const string PayloadExtension = ".sidecar";
+
+    public static string GetPayloadFilePath(string packageDirectory, string partName)
+    {
+        var fileName = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(partName)))
+            + PayloadExtension;
+        return Path.Combine(packageDirectory, fileName);
+    }
+}

--- a/src/server/dsstats.api/Services/UploadProcessingService.cs
+++ b/src/server/dsstats.api/Services/UploadProcessingService.cs
@@ -1,6 +1,7 @@
 ﻿using dsstats.db;
 using dsstats.dbServices;
 using dsstats.shared;
+using dsstats.shared.Upload;
 using Microsoft.EntityFrameworkCore;
 using System.IO.Compression;
 using System.Text;
@@ -16,6 +17,8 @@ public class UploadProcessingService(
     IImportService importService
 ) : BackgroundService
 {
+    private static readonly JsonSerializerOptions UploadJsonOptions = new(JsonSerializerDefaults.Web);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         logger.LogInformation("UploadProcessingService started");
@@ -54,11 +57,18 @@ public class UploadProcessingService(
 
         try
         {
-            // 1. Load blob
-            var replays = await LoadReplays(job.BlobFilePath);
+            if (Directory.Exists(job.BlobFilePath))
+            {
+                await ImportSpawnPlaybackPackage(job.BlobFilePath, token);
+            }
+            else
+            {
+                // 1. Load blob
+                var replays = await LoadReplays(job.BlobFilePath);
 
-            // 2. Insert into DB
-            await importService.InsertReplays(replays);
+                // 2. Insert into DB
+                await importService.InsertReplays(replays);
+            }
 
             // 3. Update job metadata
             var dbJob = await context.UploadJobs.FindAsync(job.UploadJobId);
@@ -150,5 +160,77 @@ public class UploadProcessingService(
                    ?? [];
         }
         return [];
+    }
+
+    private async Task ImportSpawnPlaybackPackage(string packageDirectory, CancellationToken token)
+    {
+        var requestPath = Path.Combine(packageDirectory, SpawnPlaybackUploadPackage.RequestFileName);
+        var manifestPath = Path.Combine(packageDirectory, SpawnPlaybackUploadPackage.ManifestFileName);
+
+        if (!File.Exists(requestPath))
+        {
+            throw new InvalidDataException("Spawn playback request file is missing.");
+        }
+
+        if (!File.Exists(manifestPath))
+        {
+            throw new InvalidDataException("Spawn playback manifest file is missing.");
+        }
+
+        UploadRequestDto? request;
+        await using (var requestStream = File.OpenRead(requestPath))
+        await using (var gzip = new GZipStream(requestStream, CompressionMode.Decompress))
+        {
+            request = await JsonSerializer.DeserializeAsync<UploadRequestDto>(
+                gzip,
+                UploadJsonOptions,
+                token);
+        }
+
+        if (request is null)
+        {
+            throw new InvalidDataException("Spawn playback request file is invalid.");
+        }
+
+        List<SpawnPlaybackUploadManifestEntryDto> manifestEntries;
+        await using (var manifestStream = File.OpenRead(manifestPath))
+        {
+            manifestEntries = await JsonSerializer.DeserializeAsync<List<SpawnPlaybackUploadManifestEntryDto>>(
+                manifestStream,
+                UploadJsonOptions,
+                token) ?? [];
+        }
+
+        Dictionary<string, SpawnPlaybackUploadPayload> payloadsByPartName = new(StringComparer.Ordinal);
+        foreach (var entry in manifestEntries)
+        {
+            if (string.IsNullOrWhiteSpace(entry.PartName)
+                || payloadsByPartName.ContainsKey(entry.PartName))
+            {
+                continue;
+            }
+
+            var payloadPath = SpawnPlaybackUploadPackage.GetPayloadFilePath(packageDirectory, entry.PartName);
+            if (!File.Exists(payloadPath))
+            {
+                continue;
+            }
+
+            var payloadLength = new FileInfo(payloadPath).Length;
+            payloadsByPartName.Add(
+                entry.PartName,
+                new(entry.PartName, payloadLength, () => File.OpenRead(payloadPath)));
+        }
+
+        var result = await importService.InsertReplayImportsWithSidecars(
+            request,
+            manifestEntries,
+            payloadsByPartName,
+            token);
+
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(result.Error ?? "Spawn playback import failed.");
+        }
     }
 }

--- a/src/server/dsstats.api/Services/UploadService.FileStore.cs
+++ b/src/server/dsstats.api/Services/UploadService.FileStore.cs
@@ -6,12 +6,9 @@ namespace dsstats.api.Services;
 
 public partial class UploadService
 {
-    private readonly string blobBaseDir = "/data/ds/replayblobs";
-    private readonly string replayBaseDir = "/data/ds/replayblobs";
-
     private async Task<string> StoreBlob(UploadDto upload)
     {
-        var appDir = Path.Combine(blobBaseDir, upload.AppGuid.ToString("N"));
+        var appDir = Path.Combine(storageOptions.BlobBaseDir, upload.AppGuid.ToString("N"));
         Directory.CreateDirectory(appDir);
         var blobFileName = $"{Guid.NewGuid():N}.blob";
         var blobFilePath = Path.Combine(appDir, blobFileName);
@@ -22,7 +19,7 @@ public partial class UploadService
 
     private async Task<string> StoreBlob(UploadRequestDto request)
     {
-        var appDir = Path.Combine(blobBaseDir, request.AppGuid.ToString("N"));
+        var appDir = Path.Combine(storageOptions.BlobBaseDir, request.AppGuid.ToString("N"));
         Directory.CreateDirectory(appDir);
 
         var fileName = $"{Guid.NewGuid():N}.json.gz";
@@ -37,7 +34,7 @@ public partial class UploadService
 
     private async Task<string> StoreReplay(Guid guid, IFormFile file)
     {
-        var appDir = Path.Combine(replayBaseDir);
+        var appDir = Path.Combine(storageOptions.ReplayBaseDir);
         Directory.CreateDirectory(appDir);
         var blobFileName = $"{guid}_{Guid.NewGuid():N}.SC2Replay";
         var replayFilePath = Path.Combine(appDir, blobFileName);

--- a/src/server/dsstats.api/Services/UploadService.SpawnPlayback.cs
+++ b/src/server/dsstats.api/Services/UploadService.SpawnPlayback.cs
@@ -1,0 +1,339 @@
+using dsstats.db;
+using dsstats.dbServices;
+using dsstats.shared;
+using dsstats.shared.Interfaces;
+using dsstats.shared.Upload;
+using Microsoft.EntityFrameworkCore;
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace dsstats.api.Services;
+
+public partial class UploadService
+{
+    private static readonly JsonSerializerOptions UploadJsonOptions = new(JsonSerializerDefaults.Web);
+    private const string SingleSpawnPlaybackSidecarPartName = "sidecar";
+
+    public async Task<ReplayImportResultDto> ProcessSpawnPlaybackUploadAsync(
+        string? replay,
+        IFormFile sidecar,
+        ushort formatVersion,
+        SpawnPlaybackCompression compression,
+        int compressedLength,
+        int uncompressedLength,
+        int unitCount,
+        CancellationToken token)
+    {
+        if (sidecar.Length == 0)
+        {
+            return FailedSingle("Invalid sidecar payload.");
+        }
+
+        ReplayDto? replayDto;
+        try
+        {
+            replayDto = JsonSerializer.Deserialize<ReplayDto>(replay ?? string.Empty, UploadJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Failed to deserialize spawn playback replay payload.");
+            return FailedSingle("Invalid replay payload.");
+        }
+
+        if (replayDto is null)
+        {
+            return FailedSingle("Invalid replay payload.");
+        }
+
+        if (sidecar.Length != compressedLength)
+        {
+            return FailedSingle("Sidecar compressed length does not match payload length.");
+        }
+
+        if (formatVersion != SpawnPlaybackSidecarCodec.FormatVersion
+            || compressedLength <= 0
+            || uncompressedLength <= 0
+            || unitCount <= 0)
+        {
+            return FailedSingle("Invalid sidecar metadata.");
+        }
+
+        if (!ImportService.IsSupportedCompression(compression))
+        {
+            return FailedSingle("Unsupported sidecar compression.");
+        }
+
+        var replayHash = replayDto.ComputeHash();
+        var uploadRequest = new UploadRequestDto
+        {
+            AppGuid = Guid.Empty,
+            Replays = [replayDto],
+        };
+        SpawnPlaybackUploadManifestEntryDto[] manifest =
+        [
+            new()
+            {
+                ReplayHash = replayHash,
+                PartName = SingleSpawnPlaybackSidecarPartName,
+                FormatVersion = formatVersion,
+                Compression = compression,
+                CompressedLength = compressedLength,
+                UncompressedLength = uncompressedLength,
+                UnitCount = unitCount,
+            }
+        ];
+
+        var packageDirectory = CreateSpawnPlaybackPackageDirectory();
+        try
+        {
+            await StoreSpawnPlaybackRequest(packageDirectory, uploadRequest, token);
+            await StoreSpawnPlaybackManifest(packageDirectory, manifest, token);
+            await StoreSpawnPlaybackSidecar(packageDirectory, SingleSpawnPlaybackSidecarPartName, sidecar, token);
+
+            await QueueSpawnPlaybackPackage(uploadRequest, packageDirectory, token);
+            return new()
+            {
+                Success = true,
+                ReplayHash = replayHash,
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            TryDeleteDirectory(packageDirectory);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            TryDeleteDirectory(packageDirectory);
+            logger.LogError(ex, "Error queueing spawn playback upload");
+            return FailedSingle("Unknown Error");
+        }
+    }
+
+    public async Task<ReplayImportBatchResultDto> ProcessSpawnPlaybackUploadAsync(
+        IFormFile? request,
+        string? manifest,
+        IFormFileCollection files,
+        CancellationToken token)
+    {
+        if (request is null || request.Length == 0)
+        {
+            return FailedBatch("Invalid replay payload.");
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest))
+        {
+            return FailedBatch("Missing sidecar manifest.");
+        }
+
+        try
+        {
+            JsonSerializer.Deserialize<List<SpawnPlaybackUploadManifestEntryDto>>(
+                manifest,
+                UploadJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Failed to deserialize spawn playback import manifest.");
+            return FailedBatch("Invalid sidecar manifest json.");
+        }
+
+        List<IFormFile> sidecarFiles = [];
+        HashSet<string> payloadPartNames = new(StringComparer.Ordinal);
+        foreach (var file in files)
+        {
+            if (string.Equals(file.Name, "request", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!payloadPartNames.Add(file.Name))
+            {
+                return FailedBatch("Duplicate sidecar payload.");
+            }
+
+            sidecarFiles.Add(file);
+        }
+
+        var packageDirectory = CreateSpawnPlaybackPackageDirectory();
+
+        try
+        {
+            var requestPath = Path.Combine(packageDirectory, SpawnPlaybackUploadPackage.RequestFileName);
+            await using (var requestFile = File.Create(requestPath))
+            {
+                await request.CopyToAsync(requestFile, token);
+            }
+
+            UploadRequestDto? uploadRequest;
+            try
+            {
+                await using var requestStream = File.OpenRead(requestPath);
+                await using var gzip = new GZipStream(requestStream, CompressionMode.Decompress);
+                uploadRequest = await JsonSerializer.DeserializeAsync<UploadRequestDto>(
+                    gzip,
+                    UploadJsonOptions,
+                    token);
+            }
+            catch (InvalidDataException ex)
+            {
+                logger.LogWarning(ex, "Failed to decompress spawn playback import request.");
+                return FailedBatchWithCleanup(packageDirectory, "Invalid replay payload gzip stream.");
+            }
+            catch (JsonException ex)
+            {
+                logger.LogWarning(ex, "Failed to deserialize spawn playback import request.");
+                return FailedBatchWithCleanup(packageDirectory, "Invalid replay payload json.");
+            }
+
+            if (uploadRequest is null)
+            {
+                return FailedBatchWithCleanup(packageDirectory, "Invalid replay payload.");
+            }
+
+            await StoreSpawnPlaybackManifest(packageDirectory, manifest, token);
+
+            foreach (var file in sidecarFiles)
+            {
+                await StoreSpawnPlaybackSidecar(packageDirectory, file.Name, file, token);
+            }
+
+            await QueueSpawnPlaybackPackage(uploadRequest, packageDirectory, token);
+            return new()
+            {
+                Success = true,
+                ReplayHashes = uploadRequest.Replays.Select(replay => replay.ComputeHash()).ToList(),
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            TryDeleteDirectory(packageDirectory);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            TryDeleteDirectory(packageDirectory);
+            logger.LogError(ex, "Error queueing spawn playback upload");
+            return FailedBatch("Unknown Error");
+        }
+    }
+
+    private string CreateSpawnPlaybackPackageDirectory()
+    {
+        var packageDirectory = Path.Combine(
+            storageOptions.BlobBaseDir,
+            "spawn-playbacks",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(packageDirectory);
+        return packageDirectory;
+    }
+
+    private static async Task StoreSpawnPlaybackRequest(
+        string packageDirectory,
+        UploadRequestDto uploadRequest,
+        CancellationToken token)
+    {
+        var requestPath = Path.Combine(packageDirectory, SpawnPlaybackUploadPackage.RequestFileName);
+        await using var fs = File.Create(requestPath);
+        await using var gz = new GZipStream(fs, CompressionLevel.Fastest);
+        await JsonSerializer.SerializeAsync(gz, uploadRequest, UploadJsonOptions, token);
+    }
+
+    private static Task StoreSpawnPlaybackManifest(
+        string packageDirectory,
+        IReadOnlyList<SpawnPlaybackUploadManifestEntryDto> manifest,
+        CancellationToken token)
+    {
+        var manifestJson = JsonSerializer.Serialize(manifest, UploadJsonOptions);
+        return StoreSpawnPlaybackManifest(packageDirectory, manifestJson, token);
+    }
+
+    private static Task StoreSpawnPlaybackManifest(
+        string packageDirectory,
+        string manifest,
+        CancellationToken token)
+    {
+        var manifestPath = Path.Combine(packageDirectory, SpawnPlaybackUploadPackage.ManifestFileName);
+        return File.WriteAllTextAsync(manifestPath, manifest, token);
+    }
+
+    private static async Task StoreSpawnPlaybackSidecar(
+        string packageDirectory,
+        string partName,
+        IFormFile sidecar,
+        CancellationToken token)
+    {
+        var payloadPath = SpawnPlaybackUploadPackage.GetPayloadFilePath(packageDirectory, partName);
+        await using var payloadFile = File.Create(payloadPath);
+        await sidecar.CopyToAsync(payloadFile, token);
+    }
+
+    private async Task QueueSpawnPlaybackPackage(
+        UploadRequestDto uploadRequest,
+        string packageDirectory,
+        CancellationToken token)
+    {
+        List<int> playerIds = [];
+        foreach (var requestName in uploadRequest.RequestNames)
+        {
+            var playerId = importService.GetOrCreatePlayerId(
+                requestName.Name,
+                requestName.RegionId,
+                requestName.RealmId,
+                requestName.ToonId);
+            playerIds.Add(playerId);
+        }
+
+        await using var context = await contextFactory.CreateDbContextAsync(token);
+        var uploadJob = new UploadJob
+        {
+            PlayerIds = playerIds.ToArray(),
+            Version = uploadRequest.AppVersion,
+            BlobFilePath = packageDirectory,
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.UploadJobs.Add(uploadJob);
+        await context.SaveChangesAsync(token);
+
+        await uploadChannel.Writer.WriteAsync(uploadJob, token);
+    }
+
+    private static ReplayImportResultDto FailedSingle(string error)
+    {
+        return new()
+        {
+            Success = false,
+            Error = error,
+        };
+    }
+
+    private static ReplayImportBatchResultDto FailedBatch(string error)
+    {
+        return new()
+        {
+            Success = false,
+            Error = error,
+        };
+    }
+
+    private static ReplayImportBatchResultDto FailedBatchWithCleanup(string packageDirectory, string error)
+    {
+        TryDeleteDirectory(packageDirectory);
+        return FailedBatch(error);
+    }
+
+    private static void TryDeleteDirectory(string packageDirectory)
+    {
+        try
+        {
+            if (Directory.Exists(packageDirectory))
+            {
+                Directory.Delete(packageDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup after a failed request.
+        }
+    }
+}

--- a/src/server/dsstats.api/Services/UploadService.cs
+++ b/src/server/dsstats.api/Services/UploadService.cs
@@ -2,6 +2,7 @@
 using dsstats.dbServices;
 using dsstats.shared.Upload;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using System.Threading.Channels;
 
 namespace dsstats.api.Services;
@@ -11,8 +12,11 @@ public partial class UploadService(
     Channel<UploadJob> uploadChannel,
     Channel<ReplayUploadJob> replaysChannel,
     IImportService importService,
+    IOptions<UploadStorageOptions> uploadStorageOptions,
     ILogger<UploadService> logger)
 {
+    private readonly UploadStorageOptions storageOptions = uploadStorageOptions.Value;
+
     public async Task<bool> ProcessUploadAsync(UploadDto uploadDto)
     {
         await using var context = await contextFactory.CreateDbContextAsync();

--- a/src/server/dsstats.api/Services/UploadStorageOptions.cs
+++ b/src/server/dsstats.api/Services/UploadStorageOptions.cs
@@ -1,0 +1,9 @@
+namespace dsstats.api.Services;
+
+public sealed class UploadStorageOptions
+{
+    public const string SectionName = "UploadStorage";
+
+    public string BlobBaseDir { get; set; } = "/data/ds/replayblobs";
+    public string ReplayBaseDir { get; set; } = "/data/ds/replayblobs";
+}

--- a/src/tests/dsstats.tests/SpawnPlaybackUploadService.Tests.cs
+++ b/src/tests/dsstats.tests/SpawnPlaybackUploadService.Tests.cs
@@ -1,0 +1,573 @@
+using dsstats.api.Services;
+using dsstats.db;
+using dsstats.dbServices;
+using dsstats.shared;
+using dsstats.shared.Interfaces;
+using dsstats.shared.Upload;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text.Json;
+using System.Threading.Channels;
+
+namespace dsstats.tests;
+
+[TestClass]
+public sealed class SpawnPlaybackUploadServiceTests
+{
+    private static readonly JsonSerializerOptions UploadJsonOptions = new(JsonSerializerDefaults.Web);
+
+    [TestMethod]
+    public async Task ProcessSpawnPlaybackUploadAsync_SingleReplayStoresPackageAndQueuesJob()
+    {
+        var tempDirectory = CreateTempDirectory();
+        await using var fixture = await UploadFixture.Create(tempDirectory, Mock.Of<IImportService>());
+        try
+        {
+            var replay = CreateReplay("Direct Strike", 900);
+            var sidecarPayload = new byte[] { 1, 2, 3, 4 };
+
+            var result = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                JsonSerializer.Serialize(replay, UploadJsonOptions),
+                CreateFormFile("sidecar", sidecarPayload),
+                SpawnPlaybackSidecarCodec.FormatVersion,
+                SpawnPlaybackCompression.GZip,
+                sidecarPayload.Length,
+                uncompressedLength: 16,
+                unitCount: 1,
+                CancellationToken.None);
+
+            Assert.IsTrue(result.Success, result.Error);
+            Assert.AreEqual(replay.ComputeHash(), result.ReplayHash);
+
+            Assert.IsTrue(await fixture.UploadChannel.Reader.WaitToReadAsync(CancellationToken.None));
+            Assert.IsTrue(fixture.UploadChannel.Reader.TryRead(out var queuedJob));
+            Assert.IsTrue(Directory.Exists(queuedJob.BlobFilePath));
+            Assert.IsTrue(File.Exists(Path.Combine(queuedJob.BlobFilePath, "request.json.gz")));
+            Assert.IsTrue(File.Exists(Path.Combine(queuedJob.BlobFilePath, "manifest.json")));
+            Assert.AreEqual(1, Directory.GetFiles(queuedJob.BlobFilePath, "*.sidecar").Length);
+
+            await using var context = await fixture.ContextFactory.CreateDbContextAsync();
+            var dbJob = await context.UploadJobs.SingleAsync();
+            Assert.AreEqual(queuedJob.UploadJobId, dbJob.UploadJobId);
+            Assert.AreEqual(string.Empty, dbJob.Version);
+            Assert.IsNull(dbJob.FinishedAt);
+            Assert.AreEqual(string.Empty, dbJob.Error);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessSpawnPlaybackUploadAsync_SingleReplayRejectsInvalidRequestsWithoutQueueing()
+    {
+        var tempDirectory = CreateTempDirectory();
+        await using var fixture = await UploadFixture.Create(tempDirectory, Mock.Of<IImportService>());
+        try
+        {
+            var replay = CreateReplay("Direct Strike", 900);
+            var replayJson = JsonSerializer.Serialize(replay, UploadJsonOptions);
+            var sidecar = CreateFormFile("sidecar", [1, 2, 3, 4]);
+
+            var invalidReplay = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                "{",
+                sidecar,
+                SpawnPlaybackSidecarCodec.FormatVersion,
+                SpawnPlaybackCompression.GZip,
+                compressedLength: 4,
+                uncompressedLength: 16,
+                unitCount: 1,
+                CancellationToken.None);
+            Assert.IsFalse(invalidReplay.Success);
+            Assert.AreEqual("Invalid replay payload.", invalidReplay.Error);
+
+            var mismatchedLength = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                replayJson,
+                sidecar,
+                SpawnPlaybackSidecarCodec.FormatVersion,
+                SpawnPlaybackCompression.GZip,
+                compressedLength: 5,
+                uncompressedLength: 16,
+                unitCount: 1,
+                CancellationToken.None);
+            Assert.IsFalse(mismatchedLength.Success);
+            Assert.AreEqual("Sidecar compressed length does not match payload length.", mismatchedLength.Error);
+
+            var invalidMetadata = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                replayJson,
+                sidecar,
+                formatVersion: 0,
+                compression: SpawnPlaybackCompression.GZip,
+                compressedLength: 4,
+                uncompressedLength: 16,
+                unitCount: 1,
+                CancellationToken.None);
+            Assert.IsFalse(invalidMetadata.Success);
+            Assert.AreEqual("Invalid sidecar metadata.", invalidMetadata.Error);
+
+            var unsupportedCompression = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                replayJson,
+                sidecar,
+                SpawnPlaybackSidecarCodec.FormatVersion,
+                (SpawnPlaybackCompression)255,
+                compressedLength: 4,
+                uncompressedLength: 16,
+                unitCount: 1,
+                CancellationToken.None);
+            Assert.IsFalse(unsupportedCompression.Success);
+            Assert.AreEqual("Unsupported sidecar compression.", unsupportedCompression.Error);
+
+            await using var context = await fixture.ContextFactory.CreateDbContextAsync();
+            Assert.AreEqual(0, await context.UploadJobs.CountAsync());
+            Assert.IsFalse(fixture.UploadChannel.Reader.TryRead(out _));
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessSpawnPlaybackUploadAsync_StoresPackageAndQueuesJob()
+    {
+        var tempDirectory = CreateTempDirectory();
+        await using var fixture = await UploadFixture.Create(tempDirectory, Mock.Of<IImportService>());
+        try
+        {
+            var replay = CreateReplay("Direct Strike", 900);
+            var sidecarPayload = new byte[] { 1, 2, 3, 4 };
+            var request = CreateUploadRequestFile(CreateUploadRequest(replay));
+            var manifest = CreateManifestJson(replay, sidecarPayload.Length);
+            var files = CreateFormFiles(request, CreateFormFile("sidecar-0", sidecarPayload));
+
+            var result = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                request,
+                manifest,
+                files,
+                CancellationToken.None);
+
+            Assert.IsTrue(result.Success, result.Error);
+            CollectionAssert.AreEqual(new[] { replay.ComputeHash() }, result.ReplayHashes);
+
+            Assert.IsTrue(await fixture.UploadChannel.Reader.WaitToReadAsync(CancellationToken.None));
+            Assert.IsTrue(fixture.UploadChannel.Reader.TryRead(out var queuedJob));
+            Assert.IsTrue(Directory.Exists(queuedJob.BlobFilePath));
+            Assert.IsTrue(File.Exists(Path.Combine(queuedJob.BlobFilePath, "request.json.gz")));
+            Assert.IsTrue(File.Exists(Path.Combine(queuedJob.BlobFilePath, "manifest.json")));
+            Assert.AreEqual(1, Directory.GetFiles(queuedJob.BlobFilePath, "*.sidecar").Length);
+
+            await using var context = await fixture.ContextFactory.CreateDbContextAsync();
+            var dbJob = await context.UploadJobs.SingleAsync();
+            Assert.AreEqual(queuedJob.UploadJobId, dbJob.UploadJobId);
+            Assert.AreEqual("test", dbJob.Version);
+            Assert.IsNull(dbJob.FinishedAt);
+            Assert.AreEqual(string.Empty, dbJob.Error);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessSpawnPlaybackUploadAsync_RejectsInvalidRequestsWithoutQueueing()
+    {
+        var tempDirectory = CreateTempDirectory();
+        await using var fixture = await UploadFixture.Create(tempDirectory, Mock.Of<IImportService>());
+        try
+        {
+            var replay = CreateReplay("Direct Strike", 900);
+            var validRequest = CreateUploadRequestFile(CreateUploadRequest(replay));
+            var validManifest = CreateManifestJson(replay, 4);
+            var validFiles = CreateFormFiles(validRequest, CreateFormFile("sidecar-0", [1, 2, 3, 4]));
+
+            var missingRequest = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                null,
+                validManifest,
+                new FormFileCollection(),
+                CancellationToken.None);
+            Assert.IsFalse(missingRequest.Success);
+            Assert.AreEqual("Invalid replay payload.", missingRequest.Error);
+
+            var invalidGzip = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                CreateFormFile("request", [1, 2, 3]),
+                validManifest,
+                validFiles,
+                CancellationToken.None);
+            Assert.IsFalse(invalidGzip.Success);
+            Assert.AreEqual("Invalid replay payload gzip stream.", invalidGzip.Error);
+
+            var missingManifest = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                validRequest,
+                null,
+                validFiles,
+                CancellationToken.None);
+            Assert.IsFalse(missingManifest.Success);
+            Assert.AreEqual("Missing sidecar manifest.", missingManifest.Error);
+
+            var duplicatePayload = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                CreateUploadRequestFile(CreateUploadRequest(replay)),
+                validManifest,
+                CreateFormFiles(
+                    CreateUploadRequestFile(CreateUploadRequest(replay)),
+                    CreateFormFile("sidecar-0", [1]),
+                    CreateFormFile("sidecar-0", [2])),
+                CancellationToken.None);
+            Assert.IsFalse(duplicatePayload.Success);
+            Assert.AreEqual("Duplicate sidecar payload.", duplicatePayload.Error);
+
+            await using var context = await fixture.ContextFactory.CreateDbContextAsync();
+            Assert.AreEqual(0, await context.UploadJobs.CountAsync());
+            Assert.IsFalse(fixture.UploadChannel.Reader.TryRead(out _));
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task UploadProcessingService_ImportsDirectoryBackedSpawnPlaybackBatchPackage()
+    {
+        var tempDirectory = CreateTempDirectory();
+        await using var serviceProvider = BuildServiceProvider(out var connection);
+        await using var fixture = await UploadFixture.Create(
+            tempDirectory,
+            serviceProvider.GetRequiredService<IImportService>(),
+            serviceProvider.GetRequiredService<IDbContextFactory<DsstatsContext>>());
+        var worker = new UploadProcessingService(
+            NullLogger<UploadProcessingService>.Instance,
+            fixture.ContextFactory,
+            fixture.UploadChannel,
+            serviceProvider.GetRequiredService<IImportService>());
+
+        try
+        {
+            var replay = CreateReplay("Direct Strike", 900);
+            var sidecarPayload = new byte[] { 5, 6, 7, 8 };
+            var request = CreateUploadRequestFile(CreateUploadRequest(replay));
+            var manifest = CreateManifestJson(replay, sidecarPayload.Length);
+
+            var result = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                request,
+                manifest,
+                CreateFormFiles(request, CreateFormFile("sidecar-0", sidecarPayload)),
+                CancellationToken.None);
+            Assert.IsTrue(result.Success, result.Error);
+
+            Assert.IsTrue(fixture.UploadChannel.Reader.TryRead(out _));
+            await worker.StartAsync(CancellationToken.None);
+
+            var job = await WaitForFinishedJob(fixture.ContextFactory);
+            Assert.IsNull(job.Error);
+
+            await using var context = await fixture.ContextFactory.CreateDbContextAsync();
+            Assert.AreEqual(1, await context.Replays.CountAsync());
+            var stored = await context.ReplaySpawnPlaybacks.SingleAsync();
+            CollectionAssert.AreEqual(sidecarPayload, stored.Payload);
+        }
+        finally
+        {
+            await worker.StopAsync(CancellationToken.None);
+            await connection.DisposeAsync();
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task UploadProcessingService_ImportsDirectoryBackedSingleSpawnPlaybackPackage()
+    {
+        var tempDirectory = CreateTempDirectory();
+        await using var serviceProvider = BuildServiceProvider(out var connection);
+        await using var fixture = await UploadFixture.Create(
+            tempDirectory,
+            serviceProvider.GetRequiredService<IImportService>(),
+            serviceProvider.GetRequiredService<IDbContextFactory<DsstatsContext>>());
+        var worker = new UploadProcessingService(
+            NullLogger<UploadProcessingService>.Instance,
+            fixture.ContextFactory,
+            fixture.UploadChannel,
+            serviceProvider.GetRequiredService<IImportService>());
+
+        try
+        {
+            var replay = CreateReplay("Direct Strike", 900);
+            var sidecarPayload = new byte[] { 5, 6, 7, 8 };
+
+            var result = await fixture.UploadService.ProcessSpawnPlaybackUploadAsync(
+                JsonSerializer.Serialize(replay, UploadJsonOptions),
+                CreateFormFile("sidecar", sidecarPayload),
+                SpawnPlaybackSidecarCodec.FormatVersion,
+                SpawnPlaybackCompression.GZip,
+                sidecarPayload.Length,
+                uncompressedLength: 16,
+                unitCount: 1,
+                CancellationToken.None);
+            Assert.IsTrue(result.Success, result.Error);
+
+            Assert.IsTrue(fixture.UploadChannel.Reader.TryRead(out _));
+            await worker.StartAsync(CancellationToken.None);
+
+            var job = await WaitForFinishedJob(fixture.ContextFactory);
+            Assert.IsNull(job.Error);
+
+            await using var context = await fixture.ContextFactory.CreateDbContextAsync();
+            Assert.AreEqual(1, await context.Replays.CountAsync());
+            var stored = await context.ReplaySpawnPlaybacks.SingleAsync();
+            CollectionAssert.AreEqual(sidecarPayload, stored.Payload);
+        }
+        finally
+        {
+            await worker.StopAsync(CancellationToken.None);
+            await connection.DisposeAsync();
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    private static ServiceProvider BuildServiceProvider(out SqliteConnection connection)
+    {
+        var services = new ServiceCollection();
+        var localConnection = new SqliteConnection("Filename=:memory:");
+        localConnection.Open();
+        connection = localConnection;
+
+        services.AddDbContextFactory<DsstatsContext>(o => o.UseSqlite(localConnection, options =>
+        {
+            options.MigrationsAssembly("dsstats.migrations.sqlite");
+        }));
+        services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<DsstatsContext>>().CreateDbContext());
+        services.AddSingleton(Mock.Of<IRatingService>());
+        services.AddSingleton<IImportService, ImportService>();
+        services.AddLogging();
+
+        var serviceProvider = services.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DsstatsContext>();
+        context.Database.EnsureDeleted();
+        context.Database.Migrate();
+        return serviceProvider;
+    }
+
+    private static async Task<UploadJob> WaitForFinishedJob(IDbContextFactory<DsstatsContext> contextFactory)
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            await using var context = await contextFactory.CreateDbContextAsync();
+            var job = await context.UploadJobs.SingleOrDefaultAsync();
+            if (job?.FinishedAt is not null)
+            {
+                return job;
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.Fail("Timed out waiting for upload job to finish.");
+        throw new UnreachableException();
+    }
+
+    private static UploadRequestDto CreateUploadRequest(ReplayDto replay)
+    {
+        return new()
+        {
+            AppGuid = Guid.NewGuid(),
+            AppVersion = "test",
+            Replays = [replay],
+        };
+    }
+
+    private static ReplayDto CreateReplay(string title, int duration)
+    {
+        return new()
+        {
+            Title = title,
+            Version = "5.0.14",
+            GameMode = GameMode.Standard,
+            RegionId = 1,
+            Gametime = new DateTime(2026, 5, 23, 12, 0, 0, DateTimeKind.Utc),
+            Duration = duration,
+            WinnerTeam = 1,
+            Players =
+            [
+                CreatePlayer(1),
+                CreatePlayer(2),
+                CreatePlayer(3),
+                CreatePlayer(4)
+            ]
+        };
+    }
+
+    private static ReplayPlayerDto CreatePlayer(int gamePos)
+    {
+        return new()
+        {
+            Name = $"Player{gamePos}",
+            Race = Commander.Terran,
+            SelectedRace = Commander.Terran,
+            GamePos = gamePos,
+            TeamId = gamePos <= 2 ? 1 : 2,
+            Result = gamePos <= 2 ? PlayerResult.Win : PlayerResult.Los,
+            Duration = 900,
+            Player = new()
+            {
+                Name = $"Player{gamePos}",
+                ToonId = new()
+                {
+                    Region = 1,
+                    Realm = 1,
+                    Id = gamePos
+                }
+            }
+        };
+    }
+
+    private static string CreateManifestJson(ReplayDto replay, int payloadLength)
+    {
+        SpawnPlaybackUploadManifestEntryDto[] manifest =
+        [
+            new()
+            {
+                ReplayHash = replay.ComputeHash(),
+                PartName = "sidecar-0",
+                FormatVersion = SpawnPlaybackSidecarCodec.FormatVersion,
+                Compression = SpawnPlaybackCompression.GZip,
+                CompressedLength = payloadLength,
+                UncompressedLength = 16,
+                UnitCount = 1,
+            }
+        ];
+        return JsonSerializer.Serialize(manifest, UploadJsonOptions);
+    }
+
+    private static IFormFile CreateUploadRequestFile(UploadRequestDto request)
+    {
+        using var compressed = new MemoryStream();
+        using (var gzip = new GZipStream(compressed, CompressionLevel.Fastest, leaveOpen: true))
+        {
+            JsonSerializer.Serialize(gzip, request, UploadJsonOptions);
+        }
+
+        return CreateFormFile("request", compressed.ToArray(), "request.json.gz");
+    }
+
+    private static FormFileCollection CreateFormFiles(IFormFile request, params IFormFile[] sidecars)
+    {
+        var files = new FormFileCollection
+        {
+            request
+        };
+
+        foreach (var sidecar in sidecars)
+        {
+            files.Add(sidecar);
+        }
+
+        return files;
+    }
+
+    private static IFormFile CreateFormFile(string name, byte[] content, string? fileName = null)
+    {
+        return new FormFile(new MemoryStream(content), 0, content.Length, name, fileName ?? name)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/octet-stream",
+        };
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "dsstats-upload-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteTempDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed class UploadFixture : IAsyncDisposable
+    {
+        private readonly ServiceProvider? serviceProvider;
+
+        private UploadFixture(
+            string tempDirectory,
+            IImportService importService,
+            IDbContextFactory<DsstatsContext> contextFactory,
+            ServiceProvider? serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+            ContextFactory = contextFactory;
+            UploadChannel = Channel.CreateUnbounded<UploadJob>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false,
+            });
+            ReplayChannel = Channel.CreateUnbounded<ReplayUploadJob>();
+            UploadService = new(
+                ContextFactory,
+                UploadChannel,
+                ReplayChannel,
+                importService,
+                Options.Create(new UploadStorageOptions
+                {
+                    BlobBaseDir = tempDirectory,
+                    ReplayBaseDir = tempDirectory,
+                }),
+                NullLogger<UploadService>.Instance);
+        }
+
+        public IDbContextFactory<DsstatsContext> ContextFactory { get; }
+        public Channel<UploadJob> UploadChannel { get; }
+        public Channel<ReplayUploadJob> ReplayChannel { get; }
+        public UploadService UploadService { get; }
+
+        public static async Task<UploadFixture> Create(
+            string tempDirectory,
+            IImportService importService,
+            IDbContextFactory<DsstatsContext>? contextFactory = null)
+        {
+            if (contextFactory is not null)
+            {
+                return new(tempDirectory, importService, contextFactory, null);
+            }
+
+            var services = new ServiceCollection();
+            var connection = new SqliteConnection("Filename=:memory:");
+            await connection.OpenAsync();
+            services.AddSingleton(connection);
+            services.AddDbContextFactory<DsstatsContext>(o => o.UseSqlite(connection, options =>
+            {
+                options.MigrationsAssembly("dsstats.migrations.sqlite");
+            }));
+
+            var serviceProvider = services.BuildServiceProvider();
+            var factory = serviceProvider.GetRequiredService<IDbContextFactory<DsstatsContext>>();
+            await using var context = await factory.CreateDbContextAsync();
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.MigrateAsync();
+            return new(tempDirectory, importService, factory, serviceProvider);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (serviceProvider is not null)
+            {
+                var connection = serviceProvider.GetRequiredService<SqliteConnection>();
+                await connection.DisposeAsync();
+                await serviceProvider.DisposeAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- route single and batch spawn playback imports through UploadService
- persist spawn playback upload packages as queued UploadJob work
- teach UploadProcessingService to import directory-backed spawn playback packages

## Validation
- dotnet build src/server/dsstats.api/dsstats.api.csproj -p:UseAppHost=false
- dotnet test src/tests/dsstats.tests/dsstats.tests.sln -p:UseAppHost=false