### PR TITLE
Add cross-browser replay folder support

### DIFF
--- a/src/mydsstats/dsstats.indexedDb/Client/dsstatsDb.ts
+++ b/src/mydsstats/dsstats.indexedDb/Client/dsstatsDb.ts
@@ -5,7 +5,7 @@ import { getReplaysFromFolder, readFileContentStream } from "./pick-replays";
 import { exportBackup, importBackup } from "./backup";
 import { MyPlayerStats } from "./stats/stats-dto";
 import { StatsService } from "./stats/stats";
-import { addDirectoryHandle, deleteDirectoryHandle, getAllDirectoryHandleEntries, getAllDirectoryHandles, getDirectoryHandle, getDirectoryHandleFromUser, renameDirectoryHandle as renameDirHandle, verifyAllDirectoryPermissions as verifyAllDirPerms } from "./file-handle-repository";
+import { addDirectoryHandle, addFallbackDirectoryFiles, deleteDirectoryHandle, DirectoryHandleEntry, getAllDirectoryHandleEntries, getAllDirectoryHandles, getDirectoryHandle, getDirectorySourceFromUser, renameDirectoryHandle as renameDirHandle, verifyAllDirectoryPermissions as verifyAllDirPerms } from "./file-handle-repository";
 import { replayListMatchesDetailProjection, replayListNeedsFullDetailCheck, replayMatchesDetailFilter } from "./replay-detail-filter";
 
 const CONFIG_KEYS = {
@@ -538,12 +538,16 @@ export async function pickDirectoryInit(
 }
 
 export async function pickDirectoryHandle(startName: string): Promise<string | null> {
-    const dirHandle = await getDirectoryHandleFromUser();
-    if (!dirHandle) {
+    const source = await getDirectorySourceFromUser();
+    if (!source) {
         return null;
     }
 
-    return await addDirectoryHandle(dirHandle, startName, undefined);
+    if (source.kind === "handle") {
+        return await addDirectoryHandle(source.handle, startName, undefined);
+    }
+
+    return await addFallbackDirectoryFiles(source.files, startName, undefined, source.displayName);
 }
 
 export async function getFileContentStream(path: string) {
@@ -1083,7 +1087,7 @@ export async function exportAllDirectoryHandles(): Promise<string[]> {
     return await getAllDirectoryHandles();
 }
 
-export async function exportAllDirectoryHandleEntries(): Promise<{ key: string; displayName: string; }[]> {
+export async function exportAllDirectoryHandleEntries(): Promise<DirectoryHandleEntry[]> {
     return await getAllDirectoryHandleEntries();
 }
 

--- a/src/mydsstats/dsstats.indexedDb/Client/file-handle-repository.ts
+++ b/src/mydsstats/dsstats.indexedDb/Client/file-handle-repository.ts
@@ -13,6 +13,19 @@ export interface StoredDirHandle {
   lastScannedAt?: number;
 }
 
+export interface DirectoryHandleEntry {
+  key: string;
+  displayName: string;
+  requiresReselect: boolean;
+  status: "bound" | "unbound";
+}
+
+export type DirectorySource =
+  | { kind: "handle"; handle: FileSystemDirectoryHandle }
+  | { kind: "files"; displayName: string; files: File[] };
+
+const fallbackFilesByRootKey = new Map<string, File[]>();
+
 // ── internal helpers ──────────────────────────────────────────────────────────
 
 async function getAllStoredEntries(): Promise<{ key: string; entry: StoredDirHandle }[]> {
@@ -51,6 +64,14 @@ export async function addDirectoryHandle(
   // Duplicate-handle check
   for (const { key, entry } of existing) {
     if (await entry.handle?.isSameEntry(handle)) {
+      if (entry.status !== "bound") {
+        await updateDirectoryHandle(key, {
+          ...entry,
+          handle,
+          status: "bound",
+          lastBoundAt: Date.now()
+        });
+      }
       return key;
     }
   }
@@ -96,10 +117,90 @@ export async function addDirectoryHandle(
   const db = await openDB();
   await new Promise<void>((resolve, reject) => {
     const tx = db.transaction(STORES.directoryHandles, "readwrite");
-    tx.objectStore(STORES.directoryHandles).put({ handle, displayName: effectiveName }, uuid);
+    tx.objectStore(STORES.directoryHandles).put({
+      handle,
+      displayName: effectiveName,
+      regionId: 0,
+      fingerprint: null,
+      status: "bound",
+      lastBoundAt: Date.now()
+    }, uuid);
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
+  return uuid;
+}
+
+export async function addFallbackDirectoryFiles(
+  files: File[],
+  startName: string,
+  rootKey?: string,
+  displayName?: string,
+): Promise<string> {
+  const existing = await getAllStoredEntries();
+  const fileIndex = createFileIndexFromFiles(files, startName);
+  const fingerprint = createDirectoryFingerprintFromFiles(files, startName);
+  const effectiveName = displayName || getFallbackDirectoryDisplayName(files);
+
+  if (rootKey) {
+    const target = existing.find((e) => e.key === rootKey);
+    if (!target) throw new Error(`Handle key "${rootKey}" not found.`);
+
+    if (target.entry.fingerprint && !matchesFingerprint(target.entry.fingerprint, fileIndex)) {
+      throw new Error(`Selected folder does not match "${target.entry.displayName}". Choose the same replay folder again.`);
+    }
+
+    const updatedEntry: StoredDirHandle = {
+      ...target.entry,
+      handle: null,
+      displayName: target.entry.displayName || effectiveName,
+      fingerprint,
+      status: "unbound",
+      lastBoundAt: Date.now()
+    };
+
+    await updateDirectoryHandle(rootKey, updatedEntry);
+    fallbackFilesByRootKey.set(rootKey, files);
+    return rootKey;
+  }
+
+  for (const { key, entry } of existing.filter((e) => e.entry.status === "unbound")) {
+    if (matchesFingerprint(entry.fingerprint, fileIndex)) {
+      await updateDirectoryHandle(key, {
+        ...entry,
+        handle: null,
+        fingerprint,
+        status: "unbound",
+        lastBoundAt: Date.now()
+      });
+      fallbackFilesByRootKey.set(key, files);
+      return key;
+    }
+  }
+
+  let uniqueName = effectiveName;
+  let suffix = 2;
+  while (existing.some((e) => e.entry.displayName === uniqueName)) {
+    uniqueName = `${effectiveName} ${suffix++}`;
+  }
+
+  const uuid = crypto.randomUUID();
+  const db = await openDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORES.directoryHandles, "readwrite");
+    tx.objectStore(STORES.directoryHandles).put({
+      handle: null,
+      displayName: uniqueName,
+      regionId: 0,
+      fingerprint,
+      status: "unbound",
+      lastBoundAt: Date.now()
+    } satisfies StoredDirHandle, uuid);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+
+  fallbackFilesByRootKey.set(uuid, files);
   return uuid;
 }
 
@@ -155,9 +256,14 @@ export async function getDirectoryHandle(key: string): Promise<StoredDirHandle |
 }
 
 /** Returns all saved entries as plain objects (no FileSystemDirectoryHandle, safe to serialize). */
-export async function getAllDirectoryHandleEntries(): Promise<{ key: string; displayName: string; }[]> {
+export async function getAllDirectoryHandleEntries(): Promise<DirectoryHandleEntry[]> {
   const entries = await getAllStoredEntries();
-  return entries.map(({ key, entry }) => ({ key, displayName: entry.displayName }));
+  return entries.map(({ key, entry }) => ({
+    key,
+    displayName: entry.displayName,
+    requiresReselect: !entry.handle && !fallbackFilesByRootKey.has(key),
+    status: entry.status ?? (entry.handle ? "bound" : "unbound")
+  }));
 }
 
 /** Returns just the UUID keys (kept for backward compatibility). */
@@ -222,6 +328,10 @@ export async function verifyAllDirectoryPermissions(keys: string[]): Promise<str
   for (const key of keys) {
     const entry = await getDirectoryHandle(key);
     if (!entry) continue;
+    if (!entry.handle && fallbackFilesByRootKey.has(key)) {
+      granted.push(key);
+      continue;
+    }
     const ok = await verifyDirectoryPermission(entry.handle);
     if (ok) granted.push(key);
   }
@@ -230,16 +340,82 @@ export async function verifyAllDirectoryPermissions(keys: string[]): Promise<str
 
 export async function getDirectoryHandleFromUser(): Promise<FileSystemDirectoryHandle | null> {
   if (!("showDirectoryPicker" in window)) {
-    throw new Error(
-      "showDirectoryPicker is not supported in this browser. File selection requires a Chromium-based browser."
-    );
+    return null;
   }
   try {
     return await (window as any).showDirectoryPicker();
   } catch (error: any) {
     if (error?.name === "AbortError") return null;
+    if (isDirectoryPickerUnsupported(error)) return null;
     throw new Error(`Failed to pick directory: ${error?.message ?? error}`);
   }
+}
+
+export async function getDirectorySourceFromUser(): Promise<DirectorySource | null> {
+  if ("showDirectoryPicker" in window) {
+    try {
+      const handle = await (window as any).showDirectoryPicker();
+      return { kind: "handle", handle };
+    } catch (error: any) {
+      if (error?.name === "AbortError") return null;
+      if (!isDirectoryPickerUnsupported(error)) {
+        throw new Error(`Failed to pick directory: ${error?.message ?? error}`);
+      }
+    }
+  }
+
+  const files = await getFallbackDirectoryFilesFromUser();
+  if (!files || files.length === 0) {
+    return null;
+  }
+
+  return {
+    kind: "files",
+    displayName: getFallbackDirectoryDisplayName(files),
+    files
+  };
+}
+
+export function getSessionFallbackFiles(rootKey: string): File[] | undefined {
+  return fallbackFilesByRootKey.get(rootKey);
+}
+
+function getFallbackDirectoryFilesFromUser(): Promise<File[] | null> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.multiple = true;
+    input.style.display = "none";
+    input.setAttribute("webkitdirectory", "");
+    (input as HTMLInputElement & { webkitdirectory?: boolean }).webkitdirectory = true;
+
+    const cleanup = () => input.remove();
+
+    input.onchange = () => {
+      const files = input.files ? Array.from(input.files) : [];
+      cleanup();
+      resolve(files.length > 0 ? files : null);
+    };
+    (input as HTMLInputElement & { oncancel?: () => void }).oncancel = () => {
+      cleanup();
+      resolve(null);
+    };
+    input.onerror = () => {
+      cleanup();
+      reject(new Error("Failed to open folder file picker."));
+    };
+
+    document.body.appendChild(input);
+    input.click();
+  });
+}
+
+function isDirectoryPickerUnsupported(error: unknown): boolean {
+  const err = error as { name?: string; message?: string };
+  return err?.name === "NotSupportedError"
+    || err?.name === "SecurityError"
+    || err?.name === "TypeError"
+    || /showDirectoryPicker|not supported|not implemented/i.test(err?.message ?? "");
 }
 
 export function selectFingerprintFiles(files: FileInfo[], count = 12) {
@@ -259,11 +435,62 @@ export function selectFingerprintFiles(files: FileInfo[], count = 12) {
   return result;
 }
 
+export function createDirectoryFingerprintFromFiles(files: File[], startName: string): DirectoryFingerprint {
+  const candidates = files
+    .filter((file) => file.name.startsWith(startName))
+    .map((file) => ({
+      record: {
+        path: getFallbackRelativePath(file),
+        name: file.name,
+        size: file.size,
+        lastModified: file.lastModified,
+      },
+      file
+    }));
+
+  return {
+    version: 1,
+    files: selectFingerprintFiles(candidates).map((entry) => ({
+      name: entry.file.name,
+      size: entry.file.size,
+      lastModified: entry.file.lastModified
+    }))
+  };
+}
+
+function createFileIndexFromFiles(files: File[], startName: string): Map<string, FileInfoRecord[]> {
+  const index = new Map<string, FileInfoRecord[]>();
+  for (const file of files) {
+    if (!file.name.startsWith(startName)) continue;
+
+    const key = `${file.name}::${file.size}`;
+    if (!index.has(key)) index.set(key, []);
+    index.get(key)!.push({
+      path: getFallbackRelativePath(file),
+      name: file.name,
+      size: file.size,
+      lastModified: file.lastModified
+    });
+  }
+
+  return index;
+}
+
+function getFallbackDirectoryDisplayName(files: File[]): string {
+  const relativePath = files.find((file) => getFallbackRelativePath(file).includes("/"));
+  const root = relativePath ? getFallbackRelativePath(relativePath).split("/")[0] : "";
+  return root || "Replay folder";
+}
+
+function getFallbackRelativePath(file: File): string {
+  return file.webkitRelativePath || file.name;
+}
+
 export function matchesFingerprint(
   fingerprint: DirectoryFingerprint | null,
   fileIndex: Map<string, FileInfoRecord[]>
 ): boolean {
-  if (!fingerprint) return false;
+  if (!fingerprint || fingerprint.files.length === 0) return false;
   let matches = 0;
 
   for (const f of fingerprint.files) {

--- a/src/mydsstats/dsstats.indexedDb/Client/pick-replays.ts
+++ b/src/mydsstats/dsstats.indexedDb/Client/pick-replays.ts
@@ -1,5 +1,5 @@
 import { DirectoryFingerprint, FileInfo, FileInfoRecord, ReplayMeta } from "./dtos";
-import { addDirectoryHandle, getDirectoryHandle, getDirectoryHandleFromUser, selectFingerprintFiles, updateDirectoryFingerprint, updateDirectoryScanState, verifyDirectoryPermission } from "./file-handle-repository";
+import { addDirectoryHandle, addFallbackDirectoryFiles, DirectorySource, getDirectoryHandle, getDirectorySourceFromUser, getSessionFallbackFiles, selectFingerprintFiles, updateDirectoryFingerprint, updateDirectoryScanState, verifyDirectoryPermission } from "./file-handle-repository";
 import { getFilesFromFolderRecursive } from "./get-files";
 
 const fileHandleMap = new Map<string, File>();
@@ -23,15 +23,56 @@ export async function getReplaysFromFolder(
     fileHandleMap.clear(); // reset
     try {
         let previousScanTime = 0;
+        let source: DirectorySource | null = null;
+        let sourceDisplayName = "";
+
         if (dirHandle === null || dirHandle === undefined) {
-            dirHandle = await getDirectoryHandleFromUser();
-            if (dirHandle === null || dirHandle === undefined) {
-                return [];
+            if (rootKey) {
+                const stored = await getDirectoryHandle(rootKey);
+                if (stored?.handle) {
+                    source = { kind: "handle", handle: stored.handle };
+                    dirHandle = stored.handle;
+                    sourceDisplayName = stored.displayName || stored.handle.name;
+                } else {
+                    const sessionFiles = getSessionFallbackFiles(rootKey);
+                    if (sessionFiles) {
+                        source = {
+                            kind: "files",
+                            displayName: stored?.displayName || "Replay folder",
+                            files: sessionFiles
+                        };
+                        sourceDisplayName = source.displayName;
+                    } else {
+                        source = await getDirectorySourceFromUser();
+                        if (!source) return [];
+
+                        if (source.kind === "handle") {
+                            rootKey = await addDirectoryHandle(source.handle, startName, rootKey);
+                            dirHandle = source.handle;
+                            sourceDisplayName = source.handle.name;
+                        } else {
+                            rootKey = await addFallbackDirectoryFiles(source.files, startName, rootKey, stored?.displayName);
+                            sourceDisplayName = stored?.displayName || source.displayName;
+                        }
+                    }
+                }
+            } else {
+                source = await getDirectorySourceFromUser();
+                if (!source) return [];
+
+                if (source.kind === "handle") {
+                    dirHandle = source.handle;
+                    rootKey = await addDirectoryHandle(source.handle, startName, rootKey);
+                    sourceDisplayName = source.handle.name;
+                } else {
+                    rootKey = await addFallbackDirectoryFiles(source.files, startName);
+                    sourceDisplayName = source.displayName;
+                }
             }
-            // Save with unique UUID key; returns existing UUID if same folder was already saved.
-            rootKey = await addDirectoryHandle(dirHandle, startName, rootKey);
         } else {
             await verifyDirectoryPermission(dirHandle);
+            source = { kind: "handle", handle: dirHandle };
+            sourceDisplayName = dirHandle.name;
         }
 
         if (rootKey) {
@@ -41,12 +82,14 @@ export async function getReplaysFromFolder(
 
         // Use the UUID (or dirHandle.name as fallback) as the path root so that
         // stored paths are globally unique across handles with the same folder name.
-        const pathRoot = rootKey ?? dirHandle.name;
-        const allRecords = await getFilesFromFolderRecursive(dirHandle, startName, true, pathRoot);
+        if (!source) return [];
+
+        const pathRoot = rootKey ?? sourceDisplayName;
+        const allRecords = await getFileInfosFromDirectorySource(source, startName, pathRoot);
 
         const pathPrefixes = new Set<string>([pathRoot]);
-        if (dirHandle.name && dirHandle.name !== pathRoot) {
-            pathPrefixes.add(dirHandle.name);
+        if (sourceDisplayName && sourceDisplayName !== pathRoot) {
+            pathPrefixes.add(sourceDisplayName);
         }
 
         const relevantMetas = metas
@@ -73,8 +116,8 @@ export async function getReplaysFromFolder(
         for (let i = 0; i < allRecords.length; i++) {
             const record = allRecords[i];
             const currentPath = record.record.path;
-            const legacyPath = dirHandle.name !== pathRoot
-                ? toLegacyPath(currentPath, pathRoot, dirHandle.name)
+            const legacyPath = sourceDisplayName !== pathRoot
+                ? toLegacyPath(currentPath, pathRoot, sourceDisplayName)
                 : null;
 
             const currentMeta = metaByPath.get(currentPath) ?? (legacyPath ? metaByPath.get(legacyPath) : undefined);
@@ -115,4 +158,38 @@ export async function readFileContentStream(path: string): Promise<File> {
     const file = fileHandleMap.get(path);
     if (!file) throw new Error(`File not found: ${path}`);
     return file;
+}
+
+async function getFileInfosFromDirectorySource(
+    source: DirectorySource,
+    startName: string,
+    pathRoot: string,
+): Promise<FileInfo[]> {
+    if (source.kind === "handle") {
+        return await getFilesFromFolderRecursive(source.handle, startName, true, pathRoot);
+    }
+
+    const out: FileInfo[] = [];
+    for (const file of source.files) {
+        if (!file.name.startsWith(startName)) continue;
+
+        out.push({
+            record: {
+                path: toFallbackPath(file, pathRoot),
+                name: file.name,
+                size: file.size,
+                lastModified: file.lastModified,
+            },
+            file,
+        });
+    }
+
+    return out;
+}
+
+function toFallbackPath(file: File, pathRoot: string): string {
+    const relativePath = file.webkitRelativePath || file.name;
+    const parts = relativePath.split("/").filter(Boolean);
+    const pathUnderRoot = parts.length > 1 ? parts.slice(1).join("/") : parts.join("/");
+    return `${pathRoot}/${pathUnderRoot}`;
 }

--- a/src/mydsstats/dsstats.indexedDb/Client/tests/pick-replays.test.ts
+++ b/src/mydsstats/dsstats.indexedDb/Client/tests/pick-replays.test.ts
@@ -15,6 +15,18 @@ const mockFile = (name: string, size: number, lastModified: number): File => ({
     text: vi.fn(),
 } as unknown as File);
 
+const mockFileWithPath = (name: string, relativePath: string, size: number, lastModified: number): File => ({
+    name,
+    size,
+    lastModified,
+    webkitRelativePath: relativePath,
+    type: 'text/plain',
+    arrayBuffer: vi.fn(),
+    slice: vi.fn(),
+    stream: vi.fn(),
+    text: vi.fn(),
+} as unknown as File);
+
 const mockFileHandle = (name: string, file: File) => ({
     kind: 'file',
     name,
@@ -80,22 +92,21 @@ describe('getReplaysFromFolder', () => {
     });
 
     it('should return an empty array if user cancels directory selection', async () => {
-        vi.spyOn(fileHandleRepository, 'getDirectoryHandleFromUser').mockResolvedValue(null);
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockResolvedValue(null);
         const result = await getReplaysFromFolder("replay", [], 10);
         expect(result).toEqual([]);
     });
 
     it('should return files from the selected directory, filtered by startName and sorted by lastModified', async () => {
-        vi.spyOn(fileHandleRepository, 'getDirectoryHandleFromUser').mockResolvedValue(
-            mockDirectoryHandle('mock-folder', {
+        const dirHandle = mockDirectoryHandle('mock-folder', {
                 'replay1.txt': mockFileHandle('replay1.txt', mockFile('replay1.txt', 100, Date.now() - 10000)),
                 'replay2.txt': mockFileHandle('replay2.txt', mockFile('replay2.txt', 200, Date.now() - 20000)),
                 'sub-folder': mockDirectoryHandle('sub-folder', {
                     'replay3.txt': mockFileHandle('replay3.txt', mockFile('replay3.txt', 300, Date.now() - 5000)),
                 }),
                 'other-file.jpg': mockFileHandle('other-file.jpg', mockFile('other-file.jpg', 50, Date.now() - 1000)),
-            })
-        );
+            });
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockResolvedValue({ kind: 'handle', handle: dirHandle });
         const result = await getReplaysFromFolder("replay", [], 10);
 
         expect(result).toHaveLength(3);
@@ -111,12 +122,11 @@ describe('getReplaysFromFolder', () => {
     });
 
     it('should filter out existing paths', async () => {
-        vi.spyOn(fileHandleRepository, 'getDirectoryHandleFromUser').mockResolvedValue(
-            mockDirectoryHandle('mock-folder', {
+        const dirHandle = mockDirectoryHandle('mock-folder', {
                 'replay1.txt': mockFileHandle('replay1.txt', mockFile('replay1.txt', 100, Date.now() - 10000)),
                 'replay2.txt': mockFileHandle('replay2.txt', mockFile('replay2.txt', 200, Date.now() - 20000)),
-            })
-        );
+            });
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockResolvedValue({ kind: 'handle', handle: dirHandle });
         const existingPaths = ['mock-folder/replay1.txt'];
         const result = await getReplaysFromFolder('replay', existingPaths, 1);
 
@@ -216,13 +226,12 @@ describe('getReplaysFromFolder', () => {
     });
 
     it('should limit the number of returned files by count', async () => {
-        vi.spyOn(fileHandleRepository, 'getDirectoryHandleFromUser').mockResolvedValue(
-            mockDirectoryHandle('mock-folder', {
+        const dirHandle = mockDirectoryHandle('mock-folder', {
                 'replay1.txt': mockFileHandle('replay1.txt', mockFile('replay1.txt', 100, Date.now() - 10000)),
                 'replay2.txt': mockFileHandle('replay2.txt', mockFile('replay2.txt', 200, Date.now() - 20000)),
                 'replay3.txt': mockFileHandle('replay3.txt', mockFile('replay3.txt', 300, Date.now() - 5000)),
-            })
-        );
+            });
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockResolvedValue({ kind: 'handle', handle: dirHandle });
         const result = await getReplaysFromFolder('replay', [], 2);
 
         expect(result).toHaveLength(2);
@@ -231,7 +240,7 @@ describe('getReplaysFromFolder', () => {
     });
 
     it('should use provided dirHandle if available', async () => {
-        const getDirectoryHandleFromUserSpy = vi.spyOn(fileHandleRepository, 'getDirectoryHandleFromUser');
+        const getDirectorySourceFromUserSpy = vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser');
         const customDirHandle = mockDirectoryHandle('custom-folder', {
             'custom-replay.txt': mockFileHandle('custom-replay.txt', mockFile('custom-replay.txt', 150, Date.now() - 100)),
         });
@@ -240,17 +249,16 @@ describe('getReplaysFromFolder', () => {
 
         expect(result).toHaveLength(1);
         expect(result[0].name).toBe('custom-replay.txt');
-        expect(getDirectoryHandleFromUserSpy).not.toHaveBeenCalled();
+        expect(getDirectorySourceFromUserSpy).not.toHaveBeenCalled();
         expect(fileHandleRepository.addDirectoryHandle).not.toHaveBeenCalled();
         expect(fileHandleRepository.verifyDirectoryPermission).toHaveBeenCalledWith(customDirHandle);
     });
 
     it('should save the directory handle if a new one is selected', async () => {
-        vi.spyOn(fileHandleRepository, 'getDirectoryHandleFromUser').mockResolvedValue(
-            mockDirectoryHandle('mock-folder', {})
-        );
+        const dirHandle = mockDirectoryHandle('mock-folder', {});
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockResolvedValue({ kind: 'handle', handle: dirHandle });
         const result = await getReplaysFromFolder("replay", [], 10);
-        expect(fileHandleRepository.getDirectoryHandleFromUser).toHaveBeenCalled();
+        expect(fileHandleRepository.getDirectorySourceFromUser).toHaveBeenCalled();
         // expect(fileHandleRepository.addDirectoryHandle).toHaveBeenCalledWith(expect.any(Object), 'mock-folder', 1);
     });
 
@@ -263,7 +271,7 @@ describe('getReplaysFromFolder', () => {
     });
 
     it('should handle errors during file system access gracefully', async () => {
-        vi.spyOn(fileHandleRepository, 'getDirectoryHandleFromUser').mockRejectedValue(new Error('Permission denied'));
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockRejectedValue(new Error('Permission denied'));
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); // Suppress console.log
         const result = await getReplaysFromFolder("replay", [], 10);
         expect(result).toEqual([]);
@@ -281,8 +289,8 @@ describe('getReplaysFromFolder', () => {
 
         it('should fetch chunks of replays', async () => {
             const dirSpy = vi
-                .spyOn(fileHandleRepository, 'getDirectoryHandleFromUser')
-                .mockResolvedValue(dirHandle);
+                .spyOn(fileHandleRepository, 'getDirectorySourceFromUser')
+                .mockResolvedValue({ kind: 'handle', handle: dirHandle });
 
             const firstChunk = await getReplaysFromFolder("replay", [], 10);
 
@@ -299,7 +307,7 @@ describe('getReplaysFromFolder', () => {
             };
 
             const updatedDirHandle = mockDirectoryHandle('chunk-test-folder', newReplays);
-            dirSpy.mockResolvedValue(updatedDirHandle);
+            dirSpy.mockResolvedValue({ kind: 'handle', handle: updatedDirHandle });
 
             const firstChunkPaths = firstChunk.map(m => m.path);
             const secondChunk = await getReplaysFromFolder('replay', firstChunkPaths, 10);
@@ -311,5 +319,63 @@ describe('getReplaysFromFolder', () => {
             const thirdChunk = await getReplaysFromFolder('replay', secondChunkPaths, 2);
             expect(thirdChunk).toHaveLength(2);
         });
+    });
+
+    it('should scan fallback folder files by webkitRelativePath', async () => {
+        const newest = Date.now() - 100;
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockResolvedValue({
+            kind: 'files',
+            displayName: 'fallback-folder',
+            files: [
+                mockFileWithPath('replay-old.SC2Replay', 'fallback-folder/replay-old.SC2Replay', 100, newest - 2000),
+                mockFileWithPath('notes.txt', 'fallback-folder/notes.txt', 50, newest - 1000),
+                mockFileWithPath('replay-new.SC2Replay', 'fallback-folder/nested/replay-new.SC2Replay', 120, newest),
+            ],
+        });
+        vi.spyOn(fileHandleRepository, 'addFallbackDirectoryFiles').mockResolvedValue('fallback-root');
+
+        const result = await getReplaysFromFolder('replay', [], 10);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].path).toBe('fallback-root/nested/replay-new.SC2Replay');
+        expect(result[1].path).toBe('fallback-root/replay-old.SC2Replay');
+    });
+
+    it('should reselect an unbound fallback folder and keep the existing root key', async () => {
+        const selectedFile = mockFileWithPath('replay1.SC2Replay', 'fallback-folder/replay1.SC2Replay', 100, Date.now());
+        vi.spyOn(fileHandleRepository, 'getDirectoryHandle').mockResolvedValue({
+            handle: null,
+            displayName: 'fallback-folder',
+            regionId: 0,
+            fingerprint: {
+                version: 1,
+                files: [{ name: selectedFile.name, size: selectedFile.size, lastModified: selectedFile.lastModified }],
+            },
+            status: 'unbound',
+        });
+        vi.spyOn(fileHandleRepository, 'getSessionFallbackFiles').mockReturnValue(undefined);
+        vi.spyOn(fileHandleRepository, 'getDirectorySourceFromUser').mockResolvedValue({
+            kind: 'files',
+            displayName: 'fallback-folder',
+            files: [selectedFile],
+        });
+        vi.spyOn(fileHandleRepository, 'addFallbackDirectoryFiles').mockResolvedValue('saved-root');
+
+        const result = await getReplaysFromFolder('replay', [], 10, null, 'saved-root');
+
+        expect(fileHandleRepository.addFallbackDirectoryFiles).toHaveBeenCalledWith([selectedFile], 'replay', 'saved-root', 'fallback-folder');
+        expect(result).toHaveLength(1);
+        expect(result[0].path).toBe('saved-root/replay1.SC2Replay');
+    });
+
+    it('should reject a fallback reselect when the fingerprint does not match', async () => {
+        const originalFile = mockFileWithPath('replay1.SC2Replay', 'fallback-folder/replay1.SC2Replay', 100, Date.now() - 1000);
+        const selectedOtherFolder = mockFileWithPath('replay2.SC2Replay', 'other-folder/replay2.SC2Replay', 200, Date.now());
+
+        const key = await fileHandleRepository.addFallbackDirectoryFiles([originalFile], 'replay', undefined, 'fallback-folder');
+
+        await expect(
+            fileHandleRepository.addFallbackDirectoryFiles([selectedOtherFolder], 'replay', key, 'fallback-folder')
+        ).rejects.toThrow('Selected folder does not match');
     });
 });

--- a/src/mydsstats/dsstats.indexedDb/Services/IndexedDbService.cs
+++ b/src/mydsstats/dsstats.indexedDb/Services/IndexedDbService.cs
@@ -286,6 +286,8 @@ public class IndexedDbService
     {
         public string Key { get; set; } = string.Empty;
         public string DisplayName { get; set; } = string.Empty;
+        public bool RequiresReselect { get; set; }
+        public string Status { get; set; } = "bound";
     }
 
     public sealed class FileInfoRecord

--- a/src/mydsstats/dsstats.indexedDb/dsstats.indexedDb.csproj
+++ b/src/mydsstats/dsstats.indexedDb/dsstats.indexedDb.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.3</Version>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
+    <Version>1.0.4</Version>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
   </PropertyGroup>
 
   <Target Name="RunWebpack" BeforeTargets="Build">

--- a/src/mydsstats/dsstats.pwa/Components/TopRow.razor
+++ b/src/mydsstats/dsstats.pwa/Components/TopRow.razor
@@ -6,13 +6,6 @@
 @implements IDisposable
 
 <div class="top-row d-flex flex-wrap align-items-center gap-2 px-4 py-3 bg-dark text-light">
-	@if (PwaUpdateService.IsUpdateAvailable)
-	{
-		<button class="btn btn-warning btn-sm" @onclick="ApplyUpdate" disabled="@isApplyingUpdate">
-			<i class="bi bi-arrow-clockwise me-1"></i>Update
-		</button>
-	}
-
 	@if (hasDirHandles)
 	{
 		<button class="btn btn-success btn-sm" @onclick="DecodeAll"
@@ -119,7 +112,27 @@
 	}
 
 	<div class="ms-auto d-flex align-items-center gap-2">
-		<span class="small text-light opacity-50">v@(DecodeService.Version.ToString())</span>
+		<span class="small text-light opacity-75">
+			@if (PwaUpdateService.WasUpdated)
+			{
+				<span>Updated to v@(DecodeService.Version.ToString()) &middot; </span>
+				<a href="/info#changelog" class="link-light link-underline-opacity-50 link-underline-opacity-100-hover">What's new</a>
+			}
+			else
+			{
+				<span>Version @(DecodeService.Version.ToString())</span>
+				@if (PwaUpdateService.IsUpdateAvailable)
+				{
+					<span> &middot; Update available</span>
+				}
+			}
+		</span>
+		@if (PwaUpdateService.IsUpdateAvailable)
+		{
+			<button class="btn btn-warning btn-sm" @onclick="ApplyUpdate" disabled="@isApplyingUpdate">
+				<i class="bi bi-arrow-clockwise me-1"></i>Reload to update
+			</button>
+		}
 		<AuthorizeView>
 			<Authorized Context="authState">
 				<span class="small text-light">@authState.User.Identity?.Name</span>

--- a/src/mydsstats/dsstats.pwa/Pages/DecodePage.razor
+++ b/src/mydsstats/dsstats.pwa/Pages/DecodePage.razor
@@ -195,7 +195,7 @@
 								<i class="bi bi-folder2-open me-2"></i>Saved Replay Folders
 							</h5>
 							<p class="text-muted small mb-0">
-								Decode a single saved folder with the selected size, or rename and remove it.
+								Chrome and Edge can keep folder access saved. Brave, Firefox, and Safari may ask you to reselect the folder before decoding.
 							</p>
 						</div>
 						@if (isLoadingFolders)
@@ -229,9 +229,20 @@
 												{
 													<span class="badge text-bg-success">Just Added</span>
 												}
+												@if (entry.RequiresReselect)
+												{
+													<span class="badge text-bg-warning">Reselect required</span>
+												}
 											</div>
 											<div class="small text-muted">
-												Decode newest @GetLimitSummary() from this folder.
+												@if (entry.RequiresReselect)
+												{
+													<span>Your browser cannot keep durable folder access. You will be asked to choose this folder again.</span>
+												}
+												else
+												{
+													<span>Decode newest @GetLimitSummary() from this folder.</span>
+												}
 											</div>
 										</div>
 										<div class="d-flex gap-1">

--- a/src/mydsstats/dsstats.pwa/Pages/InfoPage.razor
+++ b/src/mydsstats/dsstats.pwa/Pages/InfoPage.razor
@@ -28,6 +28,21 @@
                 </div>
             </div>
 
+            <!-- Changelog -->
+            <div id="changelog" class="card shadow-sm border-0 mb-4 bgchart2">
+                <div class="card-body">
+                    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+                        <h5 class="card-title mb-0">Changelog</h5>
+                        <span class="badge text-bg-primary">v1.9</span>
+                    </div>
+                    <ul class="mb-0">
+                        <li>Added replay folder selection fallback for Brave, Firefox, and Safari.</li>
+                        <li>Saved folders now show when reselecting is required by the browser.</li>
+                        <li>Improved folder matching so reselected folders are checked before decoding.</li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- Report Issues -->
             <div class="card shadow-sm border-0 mb-4 bgchart2">
                 <div class="card-body">

--- a/src/mydsstats/dsstats.pwa/Services/DecodeService.cs
+++ b/src/mydsstats/dsstats.pwa/Services/DecodeService.cs
@@ -23,7 +23,7 @@ public partial class DecodeService : IDisposable
     public bool Decoding { get; private set; }
     public ReplayDto? LatestReplay { get; private set; }
     public string? LatestReplayHash { get; private set; }
-    public static readonly Version Version = new(1, 8);
+    public static readonly Version Version = new(1, 9);
     private int _currentWorkerCount = -1;
 
     public DecodeService(IServiceScopeFactory scopeFactory, IHttpClientFactory httpClientFactory,

--- a/src/mydsstats/dsstats.pwa/Services/PwaUpdateService.cs
+++ b/src/mydsstats/dsstats.pwa/Services/PwaUpdateService.cs
@@ -14,6 +14,7 @@ public sealed class PwaUpdateService(
     public event Action? UpdateAvailableChanged;
 
     public bool IsUpdateAvailable { get; private set; }
+    public bool WasUpdated { get; private set; }
 
     public async ValueTask InitializeAsync()
     {
@@ -34,6 +35,7 @@ public sealed class PwaUpdateService(
             _module = await jsRuntime.InvokeAsync<IJSObjectReference>("import", $"./js/pwa-update.js?v={version}");
             _callbacks = DotNetObjectReference.Create(this);
             IsUpdateAvailable = await _module.InvokeAsync<bool>("initialize", _callbacks);
+            WasUpdated = await _module.InvokeAsync<bool>("consumeAppliedUpdate");
             _initialized = true;
         }
         catch (Exception ex)

--- a/src/mydsstats/dsstats.pwa/wwwroot/js/pwa-update.js
+++ b/src/mydsstats/dsstats.pwa/wwwroot/js/pwa-update.js
@@ -5,6 +5,7 @@ let applyingUpdate = false;
 let trackedInstallingWorker = null;
 let trackedWaitingWorker = null;
 let reloadFallbackId = null;
+const appliedUpdateStorageKey = "dsstats.pwa.appliedUpdate";
 
 export async function initialize(callbacks) {
   if (!("serviceWorker" in navigator)) {
@@ -34,6 +35,7 @@ export async function applyUpdate() {
 
   if (registration.waiting) {
     applyingUpdate = true;
+    markAppliedUpdatePending();
     trackWaitingWorker(registration.waiting);
     console.info("PWA update: asking waiting service worker to activate.");
     registration.waiting.postMessage({ type: "SKIP_WAITING" });
@@ -42,7 +44,18 @@ export async function applyUpdate() {
   }
 
   console.info("PWA update: no waiting service worker found, reloading.");
+  markAppliedUpdatePending();
   window.location.reload();
+}
+
+export function consumeAppliedUpdate() {
+  try {
+    const value = window.localStorage.getItem(appliedUpdateStorageKey);
+    window.localStorage.removeItem(appliedUpdateStorageKey);
+    return value === "1";
+  } catch {
+    return false;
+  }
 }
 
 export function dispose() {
@@ -120,6 +133,14 @@ function clearReloadFallback() {
   if (reloadFallbackId !== null) {
     window.clearTimeout(reloadFallbackId);
     reloadFallbackId = null;
+  }
+}
+
+function markAppliedUpdatePending() {
+  try {
+    window.localStorage.setItem(appliedUpdateStorageKey, "1");
+  } catch {
+    // Storage can be unavailable in private browsing modes; the update still works.
   }
 }
 


### PR DESCRIPTION
## Summary
- add a webkitdirectory fallback for browsers without durable File System Access folder permissions
- mark fallback replay folders as requiring reselect and verify reselected folders by fingerprint
- bump mydsstats PWA to v1.9, add a compact changelog, and improve update status messaging

## Validation
- node .\node_modules\vitest\vitest.mjs run
- node .\node_modules\webpack\bin\webpack.js
- dotnet build src/mydsstats/dsstats.pwa/dsstats.pwa.sln