### PR TITLE
Fix mydsstats replay builds

### DIFF
--- a/src/mydsstats/dsstats.indexedDb/dsstats.indexedDb.csproj
+++ b/src/mydsstats/dsstats.indexedDb/dsstats.indexedDb.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.5</Version>
-    <AssemblyVersion>1.0.5.0</AssemblyVersion>
-    <FileVersion>1.0.5.0</FileVersion>
+    <Version>1.0.6</Version>
+    <AssemblyVersion>1.0.6.0</AssemblyVersion>
+    <FileVersion>1.0.6.0</FileVersion>
   </PropertyGroup>
 
   <Target Name="RunWebpack" BeforeTargets="Build">

--- a/src/mydsstats/dsstats.pwa/Program.cs
+++ b/src/mydsstats/dsstats.pwa/Program.cs
@@ -2,6 +2,7 @@ using dsstats.indexedDb.Services;
 using dsstats.pwa;
 using dsstats.pwa.Services;
 using dsstats.shared;
+using dsstats.shared.Builder;
 using dsstats.shared.InHouse;
 using dsstats.shared.Interfaces;
 using dsstats.weblib.Replays;
@@ -93,6 +94,7 @@ builder.Services.AddScoped<AuthenticationStateProvider, InHouseAuthenticationSta
 builder.Services.AddScoped<IPlayerService, dsstats.apiServices.PlayerService>();
 builder.Services.AddScoped<IStatsService, dsstats.apiServices.StatsService>();
 builder.Services.AddScoped<IUnitLifeCostService, NoOpUnitLifeCostService>();
+builder.Services.AddSingleton<IBuilderService, UnavailableBuilderService>();
 
 builder.Services.AddSingleton<DecodeService>();
 

--- a/src/mydsstats/dsstats.pwa/Services/DecodeService.cs
+++ b/src/mydsstats/dsstats.pwa/Services/DecodeService.cs
@@ -23,7 +23,7 @@ public partial class DecodeService : IDisposable
     public bool Decoding { get; private set; }
     public ReplayDto? LatestReplay { get; private set; }
     public string? LatestReplayHash { get; private set; }
-    public static readonly Version Version = new(1, 10);
+    public static readonly Version Version = new(1, 11);
     private int _currentWorkerCount = -1;
 
     public DecodeService(IServiceScopeFactory scopeFactory, IHttpClientFactory httpClientFactory,


### PR DESCRIPTION
## What changed

- register the browser-safe `UnavailableBuilderService` for `IBuilderService` in the mydsstats PWA
- bump the mydsstats IndexedDB assembly version from `1.0.5` to `1.0.6`
- bump the displayed/uploaded mydsstats version from `1.10` to `1.11`

## Why

`ReplayBuildComponent` now injects `IBuilderService`, but the WebAssembly host did not register it. Opening a replay build therefore failed during component rendering. The browser host now uses the same unavailable implementation as the server host, keeping Windows-only build actions disabled without performing HTTP or database work.

## Validation

- `dotnet build src/mydsstats/dsstats.pwa/dsstats.pwa.csproj --no-restore`
- build completed with 0 errors and 0 .NET warnings